### PR TITLE
router

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -75,7 +75,10 @@ import { ProviderType } from "../utils/cloud";
 import { TTSConfigList } from "./tts-config";
 import { RealtimeConfigList } from "./realtime-chat/realtime-config";
 
-const ROUTER_BASE_URL = "https://llm.yeying.pub/";
+const normalizeUrl = (value: string) => value.replace(/\/+$/, "");
+const ROUTER_BASE_URL =
+  getClientConfig()?.routerBaseUrl || "https://llm.yeying.pub/";
+const ROUTER_BASE_URL_NORMALIZED = normalizeUrl(ROUTER_BASE_URL);
 const ROUTER_PROVIDERS = [ServiceProvider.OpenAI];
 
 function EditPromptModal(props: { id: string; onClose: () => void }) {
@@ -599,7 +602,9 @@ export function Settings() {
   const accessStore = useAccessStore();
   const shouldHideBalanceQuery = useMemo(() => {
     const isOpenAiUrl = accessStore.openaiUrl.includes(OPENAI_BASE_URL);
-    const isRouterUrl = accessStore.openaiUrl.includes(ROUTER_BASE_URL);
+    const isRouterUrl = normalizeUrl(accessStore.openaiUrl).includes(
+      ROUTER_BASE_URL_NORMALIZED,
+    );
 
     return (
       accessStore.hideBalanceQuery ||
@@ -659,13 +664,14 @@ export function Settings() {
       state.useCustomConfig = true;
       state.provider = ServiceProvider.OpenAI;
 
+      const normalizedOpenAIUrl = normalizeUrl(state.openaiUrl || "");
       const shouldReplaceEndpoint =
-        !state.openaiUrl ||
-        state.openaiUrl === ApiPath.OpenAI ||
-        state.openaiUrl === OPENAI_BASE_URL;
+        normalizedOpenAIUrl.length === 0 ||
+        normalizedOpenAIUrl === normalizeUrl(ApiPath.OpenAI) ||
+        normalizedOpenAIUrl === normalizeUrl(OPENAI_BASE_URL);
 
       if (shouldReplaceEndpoint || clientConfig?.isApp) {
-        state.openaiUrl = ROUTER_BASE_URL;
+        state.openaiUrl = ROUTER_BASE_URL_NORMALIZED;
       }
     });
     document.addEventListener("keydown", keydownEvent);
@@ -732,7 +738,7 @@ export function Settings() {
             aria-label={Locale.Settings.Access.OpenAI.Endpoint.Title}
             type="text"
             value={accessStore.openaiUrl}
-            placeholder={ROUTER_BASE_URL}
+            placeholder={ROUTER_BASE_URL_NORMALIZED}
             onChange={(e) =>
               accessStore.update(
                 (access) => (access.openaiUrl = e.currentTarget.value),

--- a/app/config/build.ts
+++ b/app/config/build.ts
@@ -11,6 +11,12 @@ export const getBuildConfig = () => {
   const buildMode = process.env.BUILD_MODE ?? "standalone";
   const isApp = !!process.env.BUILD_APP;
   const version = "v" + tauriConfig.package.version;
+  const routerBaseUrl =
+    (
+      process.env.ROUTER_BACKEND_URL ||
+      process.env.YEYING_BACKEND_URL ||
+      "https://llm.yeying.pub"
+    ).trim() || "https://llm.yeying.pub";
 
   const commitInfo = (() => {
     try {
@@ -41,6 +47,7 @@ export const getBuildConfig = () => {
     isApp,
     template: process.env.DEFAULT_INPUT_TEMPLATE ?? DEFAULT_INPUT_TEMPLATE,
     adminWalletAccount,
+    routerBaseUrl,
   };
 };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change
<img width="2557" height="1139" alt="image" src="https://github.com/user-attachments/assets/9ab24205-0bd0-4225-93c7-91505049874c" />

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
下面是一份可直接贴到 PR 描述里的「代码变更说明」（基于 `codex_exe.txt`  整理）。

---

## 背景 / 目标

为了让 NextChat 在对接 **router（OpenAI-compatible）** 时，能够与 router 的 **JWT 登录态**一致，并减少手动配置成本，本次改动实现：

1. 当请求目标命中 router 域名时，优先使用浏览器 `localStorage.authToken`（JWT）注入 `Authorization: Bearer <token>`；JWT 不存在/过期则完全回落到旧逻辑。JWT 过期判断依据 `exp` claim。([[datatracker.ietf.org](https://datatracker.ietf.org/doc/html/rfc7519?utm_source=chatgpt.com)][1])
2. 前端默认 `openaiUrl` 不再硬编码旧域名，改为优先读取环境变量配置，并对历史默认值做迁移。
3. UI “授权状态”与 router JWT 真实状态一致：JWT 登录成功时不再误判为 Unauthorized（避免出现“对话遇到问题”的默认提示）。

> 注：Bearer Token 通过 `Authorization` header 传递符合通用用法。([[datatracker.ietf.org](https://datatracker.ietf.org/doc/html/rfc6750?utm_source=chatgpt.com)][2])

---

## 改动内容

### 1) Router 请求头自动注入 JWT（仅 OpenAI 平台、仅 router 生效）

**文件：** `app/client/platforms/openai.ts`

* 新增同文件内的工具函数：

  * `isJwtValid(token)`：解析 JWT payload 并用 `exp` 与当前时间对比，判断 token 是否仍有效。([[datatracker.ietf.org](https://datatracker.ietf.org/doc/html/rfc7519?utm_source=chatgpt.com)][1])
  * `isRouterUrl(url)`：解析请求 URL，判断 host 是否包含 `llm.yeying.pub`
  * `getHeadersWithRouterJwt(url)`：在命中 router 且 JWT 有效时，**仅覆盖** `Authorization: Bearer <JWT>`，其余 header 维持原逻辑不变（不影响 api-key 等）
* 将 OpenAI 平台的相关请求（speech / chat（stream & non-stream）/ usage / models 等）统一从 `getHeaders()` 切换为 `getHeadersWithRouterJwt(实际请求URL)`
* **不改全局 `getHeaders()`**，避免影响 `api/config` 等其它链路

✅ 影响范围：**仅当请求目标 host 命中 router** 时才会覆盖 Authorization；Azure / Google / Anthropic 等不受影响。

---

### 2) Router 默认 base URL 配置化 + 旧默认域名迁移

**文件：**

* `app/config/build.ts`

* `app/store/access.ts`

* `app/components/settings.tsx`

* `build.ts`：新增 `routerBaseUrl` 注入到 client config：

  * 优先 `process.env.ROUTER_BACKEND_URL`
  * 次选 `process.env.YEYING_BACKEND_URL`
  * fallback：`https://llm.yeying.pub`

* `access.ts`：

  * 默认 `DEFAULT_OPENAI_URL` 改为来自 `getClientConfig().routerBaseUrl`（并做 normalize，去掉末尾 `/`）
  * 增加 `LEGACY_OPENAI_URL = https://shengnw.win`
  * bump persist version 到 **5**，新增 migration：当历史 `openaiUrl` 为空 / 等于 `ApiPath.OpenAI` / 等于 `OPENAI_BASE_URL` / 等于 legacy 默认值时，自动替换为新的默认 routerBaseUrl（normalize 后）

* `settings.tsx`：

  * Router 基准 URL 不再硬编码，改为读取 build 注入的 `routerBaseUrl`
  * 对比逻辑与 placeholder 统一使用 normalize 后的 URL，避免尾斜杠导致误判

✅ 结果：新装默认走 `ROUTER_BACKEND_URL`（或 fallback），老用户自动从 `https://shengnw.win` 迁移到新默认值。

---

### 3) UI 授权状态与 Router JWT 一致（消除 Unauthorized 误判）

**文件：** `app/store/access.ts`

* 新增：

  * `isValidJwt(token)`：同样基于 JWT `exp` 校验有效期。([[datatracker.ietf.org](https://datatracker.ietf.org/doc/html/rfc7519?utm_source=chatgpt.com)][1])
  * `isRouterEndpoint(url)`：用 `new URL(url, base)` 解析，判断 host 是否包含 `llm.yeying.pub`（并规避 SSR：`window/localStorage` 仅在浏览器存在）。([[GitHub](https://github.com/vercel/next.js/discussions/19911?utm_source=chatgpt.com)][3])
* 在 `isAuthorized()` 中增加补充分支 `routerJwtOk`：

  * 当 `openaiUrl` 指向 router 且 `localStorage.authToken` 有效 ⇒ 视为 authorized
  * **旧的 API Key / accessCode / access control 逻辑保持不变**，只是 OR 进去一条 router JWT 的“补充授权通道”

✅ 结果：用户用 router JWT 登录成功后，Chat UI 不再显示默认 Unauthorized 提示（不再误导为“对话遇到问题”）。

---

## 兼容性说明（重要）

* **无破坏性改动（No Breaking Changes）**
* JWT 不存在或过期时：完全回落到旧逻辑（API Key / accessCode）
* 仅当请求 host 命中 router 才覆盖 `Authorization`，其他 provider 不受影响
* SSR 安全：涉及 `window/localStorage` 的逻辑都做了保护（避免 `localStorage is not defined`）。([[GitHub](https://github.com/vercel/next.js/discussions/19911?utm_source=chatgpt.com)][3])

---

## 新增/更新配置项

* `.env.local`（或部署环境）可配置：

  * `ROUTER_BACKEND_URL`（优先）
  * `YEYING_BACKEND_URL`（次选）
  * 未配置时默认 `https://llm.yeying.pub` 

---

## 自测方式（建议写进 PR）

1. **JWT 注入验证**

   * 浏览器控制台设置：`localStorage.authToken = "<有效JWT>"`
   * `openaiUrl` 指向 router（`llm.yeying.pub` 或 env 指定域名）
   * 发起一次 Chat 请求，在 Network 中确认请求头为 `Authorization: Bearer <JWT>`
   * 将 JWT 置为过期/清空，确认回落到旧逻辑（API Key/accessCode）

2. **默认 URL & 迁移验证**

   * 新用户：未设置 openaiUrl 时，默认应为 `routerBaseUrl`
   * 老用户：若 openaiUrl 为 `https://shengnw.win`（或空/旧默认），升级后应自动迁移到新默认值

3. **UI 授权态验证**

   * router JWT 有效时：UI 不应显示 Unauthorized 默认提示
   * JWT 失效时：UI 行为与旧逻辑一致

---

## 本地运行（开发验证记录）

* `nohup npm run dev > tmp/nextchat-router-jwt-20260114.log 2>&1 &`
* `nohup npm run dev > tmp/nextchat-router-default-20260114.log 2>&1 &`
* `nohup npm run dev > tmp/nextchat-jwt-ui-20260114.log 2>&1 &` 

---



[1]: https://datatracker.ietf.org/doc/html/rfc7519?utm_source=chatgpt.com "RFC 7519 - JSON Web Token (JWT)"
[2]: https://datatracker.ietf.org/doc/html/rfc6750?utm_source=chatgpt.com "RFC 6750 - The OAuth 2.0 Authorization Framework"
[3]: https://github.com/vercel/next.js/discussions/19911?utm_source=chatgpt.com "localStorage is not defined - Next.js #19911"
-->
