### PR TITLE
fix: simplify auth toasts

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -41,10 +41,9 @@ import {
   getCentralUcanExpiresAt,
   isCentralModeEnabled,
 } from "../plugins/central-ucan";
-import { toast } from "sonner";
-
 import { useToastStore } from "../store/toast";
 import { useAutoSync } from "../hooks/useAutoSync";
+import { notifyErrorWithOptions } from "../plugins/show_window";
 
 const loadFunc = async () => {
   try {
@@ -53,18 +52,25 @@ const loadFunc = async () => {
     await initWalletListeners();
   } catch (error) {
     console.error("钱包检测失败:", error);
-    const innerHTML = `
-      <p>❌ 未检测到钱包</p>
-      <p class="error">请确保：</p>
-      <ul>
-        <li>•已安装 YeYing Wallet 扩展</li>
-        <li>•已启用扩展</li>
-        <li>•已在扩展设置中允许访问文件 URL（如果使用 file:// 协议）</li>
-        <li>•刷新页面后重试</li>
-      </ul>
-    `;
     localStorage.setItem("hasConnectedWallet", "false");
-    useToastStore.getState().setPendingError(innerHTML);
+    const loginMode = (getClientConfig()?.ucanLoginForceMode || "auto")
+      .trim()
+      .toLowerCase();
+    if (loginMode === "wallet") {
+      const innerHTML = `
+        <p>❌ 未检测到钱包</p>
+        <p class="error">请确保：</p>
+        <ul>
+          <li>•已安装 YeYing Wallet 扩展</li>
+          <li>•已启用扩展</li>
+          <li>•已在扩展设置中允许访问文件 URL（如果使用 file:// 协议）</li>
+          <li>•刷新页面后重试</li>
+        </ul>
+      `;
+      useToastStore.getState().setPendingError(innerHTML);
+    } else {
+      useToastStore.getState().setPendingError(null);
+    }
   }
 };
 
@@ -427,9 +433,7 @@ export function Home() {
 
   useEffect(() => {
     if (pendingError) {
-      // ⚠️ sonner 不支持 HTML，所以只能显示纯文本摘要
-      // 或者你改用 description 为简化版消息
-      toast.error("❌ 钱包连接失败", {
+      notifyErrorWithOptions("钱包连接失败", {
         description: "请安装并启用 YeYing Wallet 扩展",
         duration: 8000,
         action: {
@@ -440,7 +444,6 @@ export function Home() {
         },
       });
 
-      // 清除状态，避免重复触发
       clearError(null);
     }
   }, [pendingError, clearError]);

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 // hooks/useAuth.ts
 import { useEffect, useState } from "react";
+import { getClientConfig } from "../config/client";
 import { isValidUcanAuthorization, UCAN_AUTH_EVENT } from "../plugins/wallet";
 import { notifyError } from "../plugins/show_window";
 
@@ -8,10 +9,15 @@ export function useAuth(options?: { notify?: boolean }) {
   const shouldNotify = options?.notify === true;
   useEffect(() => {
     let cancelled = false;
+    const loginMode = (getClientConfig()?.ucanLoginForceMode || "auto")
+      .trim()
+      .toLowerCase();
+    const shouldNotifyWalletMissing =
+      shouldNotify && loginMode === "wallet";
     const check = async () => {
       if (localStorage.getItem("hasConnectedWallet") === "false") {
         if (!cancelled) {
-          if (shouldNotify) {
+          if (shouldNotifyWalletMissing) {
             notifyError("❌未检测到钱包，请先安装并连接钱包");
           }
           setIsAuthenticated(false);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import { Analytics } from "@vercel/analytics/react";
 import { Home } from "./components/home";
 import { getServerSideConfig } from "./config/server";
-import { Toaster } from "sonner";
 
 export const runtime = "nodejs";
 
@@ -14,7 +13,6 @@ export default async function App() {
       {serverConfig?.isVercel && (
         <>
           <Analytics />
-          <Toaster position="top-right" richColors /> {/* 👈 必须在这里 */}
         </>
       )}
     </>

--- a/app/plugins/show_window.ts
+++ b/app/plugins/show_window.ts
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast, type ExternalToast } from "sonner";
 
 const RECENT_TOASTS = new Map<string, number>();
 const DEDUPE_WINDOW_MS = 1500;
@@ -21,6 +21,20 @@ export const notifyError = (msg: string) => {
   const key = `error:${normalized}`;
   if (!shouldToast(key)) return;
   toast.error(normalized, { id: key, duration: 3000 });
+};
+
+export const notifyErrorWithOptions = (
+  msg: string,
+  options?: ExternalToast,
+) => {
+  const normalized = normalizeToastMessage(msg);
+  const key = `error:${normalized}`;
+  if (!shouldToast(key)) return;
+  toast.error(normalized, {
+    id: key,
+    duration: 3000,
+    ...options,
+  });
 };
 
 export const notifyInfo = (msg: string) => {


### PR DESCRIPTION
## Summary
- suppress wallet-missing error toasts in auto and central login modes
- route home-page wallet errors through the shared toast helper
- keep a single Toaster entrypoint to avoid duplicated notification behavior

## Verification
- npm run build