### PR TITLE
Fix mobile auth routing and align router/CI behavior

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: "npm"
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
       - name: install frontend dependencies
-        run: yarn install # change this to npm or pnpm depending on which one you use
+        run: npm ci
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "yarn"
+          cache: "npm"
 
       - name: Cache node_modules
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
       - name: Install dependencies
-        run: yarn install
+        run: npm ci
 
       - name: Run Jest tests
-        run: yarn test:ci
+        run: npm run test:ci

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -211,13 +211,21 @@ export function normalizeSupportedEndpoints(
 
 export function selectPreferredTextEndpoint(
   endpoints?: readonly string[],
+  options?: {
+    preferResponses?: boolean;
+  },
 ): string | undefined {
   const normalized = normalizeSupportedEndpoints(endpoints);
   if (normalized.length === 0) return undefined;
-  const order = [
-    SupportedTextEndpoint.Responses,
-    SupportedTextEndpoint.ChatCompletions,
-  ];
+  const order = options?.preferResponses
+    ? [
+        SupportedTextEndpoint.Responses,
+        SupportedTextEndpoint.ChatCompletions,
+      ]
+    : [
+        SupportedTextEndpoint.ChatCompletions,
+        SupportedTextEndpoint.Responses,
+      ];
   for (const endpoint of order) {
     if (normalized.includes(endpoint)) return endpoint;
   }

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -15,6 +15,7 @@ import RenameIcon from "../icons/rename.svg";
 import EditIcon from "../icons/rename.svg";
 import ExportIcon from "../icons/share.svg";
 import ReturnIcon from "../icons/return.svg";
+import HistoryIcon from "../icons/history.svg";
 import CopyIcon from "../icons/copy.svg";
 import SpeakIcon from "../icons/speak.svg";
 import SpeakStopIcon from "../icons/speak-stop.svg";
@@ -1711,9 +1712,10 @@ function ChatView() {
             <div className="window-actions">
               <div className={"window-action-button"}>
                 <IconButton
-                  icon={<ReturnIcon />}
+                  icon={<HistoryIcon />}
                   bordered
                   title={Locale.Chat.Actions.ChatList}
+                  aria={Locale.Chat.Actions.ChatList}
                   onClick={() => navigate(Path.Home)}
                 />
               </div>

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -216,6 +216,7 @@ function Screen() {
   const isAuth = location.pathname === Path.Auth;
   const isSd = location.pathname === Path.Sd;
   const isSdNew = location.pathname === Path.SdNew;
+  const isMobileScreen = useMobileScreen();
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -229,6 +230,7 @@ function Screen() {
       const raw = params.get("redirect") || Path.Home;
       if (!raw.startsWith("/")) return Path.Home;
       if (raw === Path.Auth) return Path.Home;
+      if (isMobileScreen && raw === Path.Chat) return Path.Home;
       return raw;
     };
 
@@ -244,6 +246,7 @@ function Screen() {
   }, [
     isAuthorized,
     isCheckingAuth,
+    isMobileScreen,
     location.pathname,
     location.search,
     navigate,
@@ -268,7 +271,6 @@ function Screen() {
     };
   }, [isAuthorized]);
 
-  const isMobileScreen = useMobileScreen();
   const shouldTightBorder =
     getClientConfig()?.isApp || (config.tightBorder && !isMobileScreen);
 

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -41,7 +41,7 @@ const cn = {
       },
     },
     Actions: {
-      ChatList: "查看消息列表",
+      ChatList: "查看会话列表",
       CompressedHistory: "查看压缩后的历史 Prompt",
       Export: "导出聊天记录",
       Copy: "复制",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -42,7 +42,7 @@ const en: LocaleType = {
       },
     },
     Actions: {
-      ChatList: "Go To Chat List",
+      ChatList: "View Chat List",
       CompressedHistory: "Compressed History Memory Prompt",
       Export: "Export All Messages as Markdown",
       Copy: "Copy",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -202,6 +202,9 @@ function toTextOnlyMessages(messages: RequestMessage[]): RequestMessage[] {
 function resolveRuntimeModelRouting(
   modelName: string,
   providerName: ServiceProvider,
+  options?: {
+    preferResponses?: boolean;
+  },
 ) {
   const models = useAppConfig.getState().models ?? [];
   const selectedModel =
@@ -213,7 +216,9 @@ function resolveRuntimeModelRouting(
   const supportedEndpoints = normalizeSupportedEndpoints(
     selectedModel?.supportedEndpoints,
   );
-  const endpointPath = selectPreferredTextEndpoint(supportedEndpoints);
+  const endpointPath = selectPreferredTextEndpoint(supportedEndpoints, {
+    preferResponses: options?.preferResponses,
+  });
 
   let requestProvider = providerName;
   if (endpointPath === SupportedTextEndpoint.Messages) {
@@ -228,6 +233,10 @@ function resolveRuntimeModelRouting(
     supportedEndpoints,
     ownedBy: selectedModel?.ownedBy,
   };
+}
+
+function hasNonImageDocumentAttachment(attachments: MultimodalContent[]): boolean {
+  return attachments.some((item) => item.type === "file_url");
 }
 
 function fillTemplateWith(input: string, modelConfig: ModelConfig) {
@@ -540,15 +549,17 @@ export const useChatStore = createPersistStore(
         const session = get().currentSession();
         const modelConfig = session.mask.modelConfig;
         const normalizedAttachments = attachments ?? [];
-        const hasFileAttachment = normalizedAttachments.some(
-          (item) => item.type === "file_url",
-        );
+        const hasDocumentAttachment =
+          hasNonImageDocumentAttachment(normalizedAttachments);
         const routing = resolveRuntimeModelRouting(
           modelConfig.model,
           modelConfig.providerName,
+          {
+            preferResponses: hasDocumentAttachment,
+          },
         );
         if (
-          hasFileAttachment &&
+          hasDocumentAttachment &&
           routing.endpointPath &&
           routing.endpointPath !== SupportedTextEndpoint.Responses
         ) {

--- a/test/text-endpoint-selection.test.ts
+++ b/test/text-endpoint-selection.test.ts
@@ -1,0 +1,27 @@
+import {
+  selectPreferredTextEndpoint,
+  SupportedTextEndpoint,
+} from "../app/client/api";
+
+describe("selectPreferredTextEndpoint", () => {
+  test("prefers chat completions by default when both endpoints are supported", () => {
+    const endpoint = selectPreferredTextEndpoint([
+      SupportedTextEndpoint.Responses,
+      SupportedTextEndpoint.ChatCompletions,
+    ]);
+
+    expect(endpoint).toBe(SupportedTextEndpoint.ChatCompletions);
+  });
+
+  test("prefers responses when explicitly requested", () => {
+    const endpoint = selectPreferredTextEndpoint(
+      [
+        SupportedTextEndpoint.ChatCompletions,
+        SupportedTextEndpoint.Responses,
+      ],
+      { preferResponses: true },
+    );
+
+    expect(endpoint).toBe(SupportedTextEndpoint.Responses);
+  });
+});


### PR DESCRIPTION
## Summary
- fix mobile auth redirect behavior so mobile users land on the chat list instead of the chat detail route
- prefer `/v1/chat/completions` when both text endpoints are available, but switch to `/v1/responses` for non-image document attachments such as PDF
- update GitHub Actions workflows to use npm instead of yarn so CI matches the repository `packageManager` and lockfile

## Testing
- `npx tsc --noEmit`
- CI workflow changes only for the npm migration

## Notes
- Jest is currently not runnable in this workspace without additional repo cleanup because the existing test environment hits a `.next/standalone` haste collision and a module resolution issue for `@yeying-community/web3-bs`.