### PR TITLE
Fix GPT image quality and image preview controls

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -24,7 +24,7 @@ import {
   streamWithThink,
 } from "@/app/utils/chat";
 import { cloudflareAIGatewayUrl } from "@/app/utils/cloudflare";
-import { ModelSize, DalleQuality, DalleStyle } from "@/app/typing";
+import { DalleStyle, ImageQuality, ModelSize } from "@/app/typing";
 
 import {
   ChatOptions,
@@ -68,6 +68,7 @@ import {
   getMessageTextContent,
   isVisionModel,
   isDalle3 as _isDalle3,
+  isGptImageModel,
   getTimeoutMSByModel,
 } from "@/app/utils";
 import { fetch } from "@/app/utils/stream";
@@ -102,8 +103,21 @@ export interface DalleRequestPayload {
   response_format: "url" | "b64_json";
   n: number;
   size: ModelSize;
-  quality: DalleQuality;
+  quality: ImageQuality;
   style: DalleStyle;
+}
+
+const dalleQualityValues = ["standard", "hd"];
+const gptImageQualityValues = ["auto", "low", "medium", "high"];
+
+function resolveImageQuality(model: string, quality?: ImageQuality) {
+  if (_isDalle3(model)) {
+    return dalleQualityValues.includes(quality ?? "") ? quality : "standard";
+  }
+  if (isGptImageModel(model)) {
+    return gptImageQualityValues.includes(quality ?? "") ? quality : "auto";
+  }
+  return quality;
 }
 
 const ROUTER_HOST = "llm.yeying.pub";
@@ -954,8 +968,16 @@ export class ChatGPTApi implements LLMApi {
           size: options.config?.size ?? "1024x1024",
         };
         if (isDalle3) {
-          imagePayload.quality = options.config?.quality ?? "standard";
+          imagePayload.quality = resolveImageQuality(
+            resolvedModel,
+            options.config?.quality,
+          );
           imagePayload.style = options.config?.style ?? "vivid";
+        } else if (isGptImageModel(resolvedModel)) {
+          imagePayload.quality = resolveImageQuality(
+            resolvedModel,
+            options.config?.quality,
+          );
         }
         requestPayload = imagePayload;
       } else {

--- a/app/components/chat.module.scss
+++ b/app/components/chat.module.scss
@@ -517,6 +517,7 @@
   box-sizing: border-box;
   border-radius: 10px;
   border: rgba($color: #888, $alpha: 0.2) 1px solid;
+  cursor: zoom-in;
 }
 
 @media only screen and (max-width: 600px) {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -70,6 +70,7 @@ import {
   getMessageImages,
   getMessageTextContent,
   isDalle3,
+  isGptImageModel,
   isVisionModel,
   safeLocalStorage,
   getModelSizes,
@@ -86,7 +87,13 @@ import { getCurrentAccount } from "../plugins/wallet";
 import dynamic from "next/dynamic";
 
 import { ChatControllerPool } from "../client/controller";
-import { DalleQuality, DalleStyle, ModelSize } from "../typing";
+import {
+  DalleQuality,
+  DalleStyle,
+  GptImageQuality,
+  ImageQuality,
+  ModelSize,
+} from "../typing";
 import { Prompt, usePromptStore } from "../store/prompt";
 import Locale from "../locales";
 
@@ -604,10 +611,25 @@ export function ChatActions(props: {
   const [showStyleSelector, setShowStyleSelector] = useState(false);
   const modelSizes = getModelSizes(currentModel);
   const dalle3Qualitys: DalleQuality[] = ["standard", "hd"];
+  const gptImageQualitys: GptImageQuality[] = ["auto", "high", "medium", "low"];
   const dalle3Styles: DalleStyle[] = ["vivid", "natural"];
   const currentSize =
     session.mask.modelConfig?.size ?? ("1024x1024" as ModelSize);
-  const currentQuality = session.mask.modelConfig?.quality ?? "standard";
+  const qualityOptions: ImageQuality[] = isDalle3(currentModel)
+    ? dalle3Qualitys
+    : isGptImageModel(currentModel)
+      ? gptImageQualitys
+      : [];
+  const defaultQuality: ImageQuality = isDalle3(currentModel)
+    ? "standard"
+    : "auto";
+  const storedQuality = session.mask.modelConfig?.quality as
+    | ImageQuality
+    | undefined;
+  const currentQuality =
+    storedQuality && qualityOptions.includes(storedQuality)
+      ? storedQuality
+      : defaultQuality;
   const currentStyle = session.mask.modelConfig?.style ?? "vivid";
 
   const isMobileScreen = useMobileScreen();
@@ -750,6 +772,11 @@ export function ChatActions(props: {
                 session.mask.modelConfig.model = model as ModelType;
                 session.mask.modelConfig.providerName =
                   providerName as ServiceProvider;
+                session.mask.modelConfig.quality = isGptImageModel(model)
+                  ? "auto"
+                  : isDalle3(model)
+                    ? "standard"
+                    : session.mask.modelConfig.quality;
                 session.mask.syncGlobalConfig = false;
               });
               if (providerName == ServiceProvider.Volcengine) {
@@ -793,7 +820,7 @@ export function ChatActions(props: {
           />
         )}
 
-        {isDalle3(currentModel) && (
+        {qualityOptions.length > 0 && (
           <ChatAction
             onClick={() => setShowQualitySelector(true)}
             text={currentQuality}
@@ -804,14 +831,14 @@ export function ChatActions(props: {
         {showQualitySelector && (
           <Selector
             defaultSelectedValue={currentQuality}
-            items={dalle3Qualitys.map((m) => ({
+            items={qualityOptions.map((m) => ({
               title: m,
               value: m,
             }))}
             onClose={() => setShowQualitySelector(false)}
             onSelection={(q) => {
               if (q.length === 0) return;
-              const quality = q[0];
+              const quality = q[0] as ImageQuality;
               chatStore.updateTargetSession(session, (session) => {
                 session.mask.modelConfig.quality = quality;
               });

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -106,6 +106,7 @@ import {
   Modal,
   Selector,
   showConfirm,
+  showImageModal,
   showPrompt,
   showToast,
 } from "./ui-lib";
@@ -2083,6 +2084,9 @@ function ChatView() {
                                 className={styles["chat-message-item-image"]}
                                 src={messageImages[0]}
                                 alt=""
+                                onClick={() =>
+                                  showImageModal(messageImages[0], true)
+                                }
                               />
                             )}
                             {messageImages.length > 1 && (
@@ -2104,6 +2108,9 @@ function ChatView() {
                                       key={index}
                                       src={image}
                                       alt=""
+                                      onClick={() =>
+                                        showImageModal(image, true)
+                                      }
                                     />
                                   );
                                 })}

--- a/app/components/sd/image-endpoint-schema-utils.ts
+++ b/app/components/sd/image-endpoint-schema-utils.ts
@@ -1,5 +1,22 @@
 import type { ImageEndpointSchema } from "./image-endpoint-schemas";
 
+function isGptImageModel(model: string) {
+  return model.toLowerCase().startsWith("gpt-image");
+}
+
+function getDefaultQuality(model: string) {
+  return isGptImageModel(model) ? "auto" : "standard";
+}
+
+function resolveImageQuality(model: string, quality?: string) {
+  const values = isGptImageModel(model)
+    ? ["auto", "low", "medium", "high"]
+    : ["standard", "hd"];
+  return quality && values.includes(quality)
+    ? quality
+    : getDefaultQuality(model);
+}
+
 export type ResolvedImageResult = NonNullable<
   ReturnType<ImageEndpointSchema["resolveImageResult"]>
 >;
@@ -14,7 +31,7 @@ export function buildOpenAIImageEditFormData(data: {
   body.append("model", data.model);
   body.append("prompt", data.params.prompt || "");
   body.append("size", data.params.size || "1024x1024");
-  body.append("quality", data.params.quality || "standard");
+  body.append("quality", resolveImageQuality(data.model, data.params.quality));
   body.append("style", data.params.style || "vivid");
   if (data.sourceImage) {
     body.append("image", data.sourceImage, "image.png");

--- a/app/components/sd/image-endpoint-schemas.ts
+++ b/app/components/sd/image-endpoint-schemas.ts
@@ -4,6 +4,46 @@ import {
   resolveOpenAIImageResult,
 } from "./image-endpoint-schema-utils";
 
+function isGptImageModel(model?: string) {
+  return model?.toLowerCase().startsWith("gpt-image") ?? false;
+}
+
+function resolveImageQuality(model: string, quality?: string) {
+  const values = isGptImageModel(model)
+    ? ["auto", "low", "medium", "high"]
+    : ["standard", "hd"];
+  const defaultQuality = isGptImageModel(model) ? "auto" : "standard";
+  return quality && values.includes(quality) ? quality : defaultQuality;
+}
+
+function getImageQualityParam(model?: string): ImageParamSchema {
+  if (isGptImageModel(model)) {
+    return {
+      name: Locale.SdPanel.ImageQuality,
+      value: "quality",
+      type: "select",
+      default: "auto",
+      options: [
+        { name: "auto", value: "auto" },
+        { name: "high", value: "high" },
+        { name: "medium", value: "medium" },
+        { name: "low", value: "low" },
+      ],
+    };
+  }
+
+  return {
+    name: Locale.SdPanel.ImageQuality,
+    value: "quality",
+    type: "select",
+    default: "standard",
+    options: [
+      { name: "standard", value: "standard" },
+      { name: "hd", value: "hd" },
+    ],
+  };
+}
+
 export type ImageEndpointType = "images-generation" | "images-edits";
 export type ImageFormMode = "generation" | "editing";
 
@@ -66,17 +106,6 @@ const imageSizeParam: ImageParamSchema = {
   ],
 };
 
-const imageQualityParam: ImageParamSchema = {
-  name: Locale.SdPanel.ImageQuality,
-  value: "quality",
-  type: "select",
-  default: "standard",
-  options: [
-    { name: "standard", value: "standard" },
-    { name: "hd", value: "hd" },
-  ],
-};
-
 const imageStyleParam: ImageParamSchema = {
   name: Locale.SdPanel.ImageStyle,
   value: "style",
@@ -93,10 +122,10 @@ export const imageEndpointSchemas: Record<
   ImageEndpointSchema
 > = {
   "images-generation": {
-    params: () => [
+    params: (data) => [
       promptParam,
       imageSizeParam,
-      imageQualityParam,
+      getImageQualityParam(data?.model),
       imageStyleParam,
     ],
     buildRequestBody: ({ model, params }) => ({
@@ -105,7 +134,7 @@ export const imageEndpointSchemas: Record<
       response_format: "b64_json",
       n: 1,
       size: params.size || "1024x1024",
-      quality: params.quality || "standard",
+      quality: resolveImageQuality(model, params.quality),
       style: params.style || "vivid",
     }),
     resolveImageResult: resolveOpenAIImageResult,
@@ -116,10 +145,10 @@ export const imageEndpointSchemas: Record<
       "",
   },
   "images-edits": {
-    params: () => [
+    params: (data) => [
       promptParam,
       imageSizeParam,
-      imageQualityParam,
+      getImageQualityParam(data?.model),
       imageStyleParam,
     ],
     buildRequestBody: buildOpenAIImageEditFormData,

--- a/app/components/sd/image-registry.ts
+++ b/app/components/sd/image-registry.ts
@@ -65,7 +65,11 @@ function buildRuntimeImageModelForMode(
     providerName,
     endpointType,
     supportsImage: true,
-    params: (data: any) => getImageEndpointSchema(endpointType).params(data),
+    params: (data: any) =>
+      getImageEndpointSchema(endpointType).params({
+        ...data,
+        model: model.name,
+      }),
   };
 }
 

--- a/app/components/ui-lib.tsx
+++ b/app/components/ui-lib.tsx
@@ -9,8 +9,12 @@ import ConfirmIcon from "../icons/confirm.svg";
 import CancelIcon from "../icons/cancel.svg";
 import MaxIcon from "../icons/max.svg";
 import MinIcon from "../icons/min.svg";
+import DownloadIcon from "../icons/download.svg";
+import AddIcon from "../icons/add.svg";
+import ZoomIcon from "../icons/zoom.svg";
 
 import Locale from "../locales";
+import { isDesktopAppRuntime, saveWithDialog, writeFile } from "../tauri";
 
 import { createRoot } from "react-dom/client";
 import React, {
@@ -25,6 +29,88 @@ import React, {
 import { IconButton } from "./button";
 import { Avatar } from "./emoji";
 import clsx from "clsx";
+
+function getImageFileExtension(blob: Blob, src: string) {
+  const mimeExtension = blob.type.split("/")[1]?.split("+")[0];
+  if (mimeExtension) return mimeExtension === "jpeg" ? "jpg" : mimeExtension;
+
+  try {
+    const pathname = new URL(src).pathname;
+    const extension = pathname.split(".").pop();
+    if (extension && extension.length <= 5) return extension;
+  } catch {
+    // Ignore non-URL sources such as data URLs.
+  }
+
+  return "png";
+}
+
+async function getImageBlob(src: string) {
+  if (src.startsWith("data:")) {
+    const response = await fetch(src);
+    return await response.blob();
+  }
+
+  const response = await fetch(src);
+  if (!response.ok)
+    throw new Error(`Image download failed: ${response.status}`);
+  return await response.blob();
+}
+
+async function downloadImage(src: string) {
+  try {
+    const blob = await getImageBlob(src);
+    const extension = getImageFileExtension(blob, src);
+    const filename = `image-${Date.now()}.${extension}`;
+
+    if (isDesktopAppRuntime()) {
+      const path = await saveWithDialog({
+        defaultPath: filename,
+        filters: [
+          {
+            name: `${extension.toUpperCase()} Image`,
+            extensions: [extension],
+          },
+          {
+            name: "All Files",
+            extensions: ["*"],
+          },
+        ],
+      });
+
+      if (!path) return;
+
+      await writeFile(path, new Uint8Array(await blob.arrayBuffer()));
+      showToast(Locale.Download.Success);
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(blob);
+    const element = document.createElement("a");
+    element.href = objectUrl;
+    element.download = filename;
+    element.style.display = "none";
+    document.body.appendChild(element);
+    element.click();
+    element.remove();
+    URL.revokeObjectURL(objectUrl);
+    showToast(Locale.Download.Success);
+  } catch {
+    try {
+      const element = document.createElement("a");
+      element.href = src;
+      element.download = `image-${Date.now()}.png`;
+      element.target = "_blank";
+      element.rel = "noopener noreferrer";
+      element.style.display = "none";
+      document.body.appendChild(element);
+      element.click();
+      element.remove();
+    } catch {
+      showToast(Locale.Download.Failed);
+    }
+  }
+}
 
 export function Popover(props: {
   children: React.ReactNode;
@@ -462,20 +548,114 @@ export function showImageModal(
   showModal({
     title: Locale.Export.Image.Modal,
     defaultMax: defaultMax,
-    children: (
-      <div style={{ display: "flex", justifyContent: "center", ...boxStyle }}>
+    children: <ImagePreview img={img} style={style} boxStyle={boxStyle} />,
+  });
+}
+
+function ImagePreview(props: {
+  img: string;
+  style?: CSSProperties;
+  boxStyle?: CSSProperties;
+}) {
+  const [zoom, setZoom] = useState(1);
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+  const updateZoom = useCallback((nextZoom: number) => {
+    setZoom(Math.min(5, Math.max(0.25, Number(nextZoom.toFixed(2)))));
+  }, []);
+
+  const imageWidth =
+    naturalSize.width > 0 ? naturalSize.width * zoom : undefined;
+  const imageHeight =
+    naturalSize.height > 0 ? naturalSize.height * zoom : undefined;
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", gap: 8 }}>
+          <IconButton
+            icon={<DownloadIcon />}
+            text={Locale.Export.Download}
+            bordered
+            onClick={() => void downloadImage(props.img)}
+          />
+          <IconButton
+            icon={<AddIcon />}
+            bordered
+            title="Zoom in"
+            aria="Zoom in"
+            onClick={() => updateZoom(zoom + 0.25)}
+          />
+          <IconButton
+            icon={<MinIcon />}
+            bordered
+            title="Zoom out"
+            aria="Zoom out"
+            onClick={() => updateZoom(zoom - 0.25)}
+          />
+          <IconButton
+            icon={<ZoomIcon />}
+            text={`${Math.round(zoom * 100)}%`}
+            bordered
+            title="Reset zoom"
+            onClick={() => updateZoom(1)}
+          />
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          overflow: "auto",
+          minHeight: 0,
+          flex: 1,
+          ...props.boxStyle,
+        }}
+        onWheel={(e) => {
+          if (!e.ctrlKey && !e.metaKey) return;
+          e.preventDefault();
+          updateZoom(zoom + (e.deltaY < 0 ? 0.1 : -0.1));
+        }}
+      >
         <img
-          src={img}
+          src={props.img}
           alt="preview"
-          style={
-            style ?? {
-              maxWidth: "100%",
-            }
-          }
+          draggable={false}
+          onLoad={(e) => {
+            setNaturalSize({
+              width: e.currentTarget.naturalWidth,
+              height: e.currentTarget.naturalHeight,
+            });
+          }}
+          style={{
+            ...props.style,
+            width: imageWidth,
+            height: imageHeight,
+            maxWidth: zoom === 1 ? props.style?.maxWidth : "none",
+            maxHeight: zoom === 1 ? props.style?.maxHeight : "none",
+            objectFit: "contain",
+            transition: "width 0.12s ease, height 0.12s ease",
+          }}
         ></img>
       </div>
-    ),
-  });
+    </div>
+  );
 }
 
 export function Selector<T>(props: {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -129,7 +129,7 @@ const cn = {
     },
     Image: {
       Toast: "正在生成截图",
-      Modal: "长按或右键保存图片",
+      Modal: "查看图片",
     },
     Artifacts: {
       Title: "分享页面",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -130,7 +130,7 @@ const en: LocaleType = {
     },
     Image: {
       Toast: "Capturing Image...",
-      Modal: "Long press or right click to save image",
+      Modal: "View Image",
     },
     Artifacts: {
       Title: "Share Artifacts",

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -1,5 +1,5 @@
 import { LLMModel } from "../client/api";
-import { DalleQuality, DalleStyle, ModelSize } from "../typing";
+import { DalleStyle, ImageQuality, ModelSize } from "../typing";
 import { getClientConfig } from "../config/client";
 import {
   DEFAULT_INPUT_TEMPLATE,
@@ -80,7 +80,7 @@ export const createDefaultConfig = () => {
       enableInjectSystemPrompts: true,
       template: config?.template ?? DEFAULT_INPUT_TEMPLATE,
       size: "1024x1024" as ModelSize,
-      quality: "standard" as DalleQuality,
+      quality: "auto" as ImageQuality,
       style: "vivid" as DalleStyle,
     },
 

--- a/app/typing.ts
+++ b/app/typing.ts
@@ -10,6 +10,8 @@ export interface RequestMessage {
 
 export type DalleSize = "1024x1024" | "1792x1024" | "1024x1792";
 export type DalleQuality = "standard" | "hd";
+export type GptImageQuality = "auto" | "low" | "medium" | "high";
+export type ImageQuality = DalleQuality | GptImageQuality;
 export type DalleStyle = "vivid" | "natural";
 
 export type ModelSize =

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -371,6 +371,10 @@ export function isDalle3(model: string) {
   return "dall-e-3" === model;
 }
 
+export function isGptImageModel(model: string) {
+  return model.toLowerCase().startsWith("gpt-image");
+}
+
 export function getTimeoutMSByModel(model: string) {
   model = model.toLowerCase();
   if (
@@ -388,7 +392,7 @@ export function getTimeoutMSByModel(model: string) {
 }
 
 export function getModelSizes(model: string): ModelSize[] {
-  if (isDalle3(model)) {
+  if (isDalle3(model) || isGptImageModel(model)) {
     return ["1024x1024", "1792x1024", "1024x1792"];
   }
   if (model.toLowerCase().includes("cogview")) {

--- a/test/sd-image-endpoint-schema-utils.test.ts
+++ b/test/sd-image-endpoint-schema-utils.test.ts
@@ -38,6 +38,32 @@ describe("image endpoint schema utils", () => {
     expect(maskFile.size).toBe(maskImage.size);
   });
 
+  test("uses gpt-image quality defaults for edits", () => {
+    const sourceImage = new Blob(["source"], { type: "image/png" });
+
+    const body = buildOpenAIImageEditFormData({
+      model: "gpt-image-2",
+      params: {
+        prompt: "edit this image",
+      },
+      sourceImage,
+    });
+
+    expect(body.get("quality")).toBe("auto");
+  });
+
+  test("ignores stale dall-e quality for gpt-image edits", () => {
+    const body = buildOpenAIImageEditFormData({
+      model: "gpt-image-2",
+      params: {
+        prompt: "edit this image",
+        quality: "standard",
+      },
+    });
+
+    expect(body.get("quality")).toBe("auto");
+  });
+
   test("prefers b64_json when present", () => {
     expect(
       resolveOpenAIImageResult({


### PR DESCRIPTION
## Summary
- handle GPT Image quality values separately from DALL-E quality values
- normalize stale image quality values before sending image requests
- add image preview zoom controls and an explicit download action

## Tests
- npm run test:ci -- --runInBand test/sd-image-endpoint-schema-utils.test.ts
- npx eslint app/typing.ts app/utils.ts app/store/config.ts app/client/platforms/openai.ts app/components/chat.tsx app/components/ui-lib.tsx app/components/sd/image-endpoint-schema-utils.ts app/components/sd/image-endpoint-schemas.ts app/components/sd/image-registry.ts app/locales/cn.ts app/locales/en.ts test/sd-image-endpoint-schema-utils.test.ts