### PR TITLE
Refine skill sessions and first-message flow

### DIFF
--- a/app/command.ts
+++ b/app/command.ts
@@ -7,6 +7,7 @@ interface Commands {
   fill?: Command;
   submit?: Command;
   mask?: Command;
+  skill?: Command;
   code?: Command;
   settings?: Command;
 }

--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -13,8 +13,8 @@ import { useChatStore } from "../store";
 import Locale from "../locales";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Path } from "../constant";
-import { MaskAvatar } from "./mask";
-import { Mask } from "../store/mask";
+import { SkillAvatar } from "./mask";
+import { Skill } from "../store/skill";
 import { useRef, useEffect } from "react";
 import { showConfirm } from "./ui-lib";
 import { useMobileScreen } from "../utils";
@@ -32,7 +32,7 @@ export function ChatItem(props: {
   id: string;
   index: number;
   narrow?: boolean;
-  mask: Mask;
+  skill: Skill;
 }) {
   const draggableRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -66,9 +66,9 @@ export function ChatItem(props: {
           {props.narrow ? (
             <div className={styles["chat-item-narrow"]}>
               <div className={clsx(styles["chat-item-avatar"], "no-dark")}>
-                <MaskAvatar
-                  avatar={props.mask.avatar}
-                  model={props.mask.modelConfig.model}
+                <SkillAvatar
+                  avatar={props.skill.avatar}
+                  model={props.skill.modelConfig.model}
                 />
               </div>
               <div className={styles["chat-item-narrow-count"]}>
@@ -169,7 +169,7 @@ export function ChatList(props: { narrow?: boolean }) {
                   }
                 }}
                 narrow={props.narrow}
-                mask={item.mask}
+                skill={item.mask}
               />
             ))}
             {provided.placeholder}

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -660,8 +660,9 @@ export function ChatActions(props: {
       // show next model to default model if exist
       let nextModel = models.find((model) => model.isDefault) || models[0];
       chatStore.updateTargetSession(session, (session) => {
-        session.mask.modelConfig.model = nextModel.name;
-        session.mask.modelConfig.providerName = nextModel?.provider
+        const sessionSkill = session.mask;
+        sessionSkill.modelConfig.model = nextModel.name;
+        sessionSkill.modelConfig.providerName = nextModel?.provider
           ?.providerName as ServiceProvider;
       });
       showToast(
@@ -773,15 +774,16 @@ export function ChatActions(props: {
               if (s.length === 0) return;
               const [model, providerName] = getModelProvider(s[0]);
               chatStore.updateTargetSession(session, (session) => {
-                session.mask.modelConfig.model = model as ModelType;
-                session.mask.modelConfig.providerName =
+                const sessionSkill = session.mask;
+                sessionSkill.modelConfig.model = model as ModelType;
+                sessionSkill.modelConfig.providerName =
                   providerName as ServiceProvider;
-                session.mask.modelConfig.quality = isGptImageModel(model)
+                sessionSkill.modelConfig.quality = isGptImageModel(model)
                   ? "auto"
                   : isDalle3(model)
                     ? "standard"
-                    : session.mask.modelConfig.quality;
-                session.mask.syncGlobalConfig = false;
+                    : sessionSkill.modelConfig.quality;
+                sessionSkill.syncGlobalConfig = false;
               });
               if (providerName == ServiceProvider.Volcengine) {
                 const selectedModel = models.find(
@@ -817,7 +819,8 @@ export function ChatActions(props: {
               if (s.length === 0) return;
               const size = s[0];
               chatStore.updateTargetSession(session, (session) => {
-                session.mask.modelConfig.size = size;
+                const sessionSkill = session.mask;
+                sessionSkill.modelConfig.size = size;
               });
               showToast(size);
             }}
@@ -844,7 +847,8 @@ export function ChatActions(props: {
               if (q.length === 0) return;
               const quality = q[0] as ImageQuality;
               chatStore.updateTargetSession(session, (session) => {
-                session.mask.modelConfig.quality = quality;
+                const sessionSkill = session.mask;
+                sessionSkill.modelConfig.quality = quality;
               });
               showToast(quality);
             }}
@@ -871,7 +875,8 @@ export function ChatActions(props: {
               if (s.length === 0) return;
               const style = s[0];
               chatStore.updateTargetSession(session, (session) => {
-                session.mask.modelConfig.style = style;
+                const sessionSkill = session.mask;
+                sessionSkill.modelConfig.style = style;
               });
               showToast(style);
             }}
@@ -1386,9 +1391,10 @@ function ChatView() {
   };
 
   const onPinMessage = (message: ChatMessage) => {
-    chatStore.updateTargetSession(session, (session) =>
-      session.mask.context.push(message),
-    );
+    chatStore.updateTargetSession(session, (session) => {
+      const sessionSkill = session.mask;
+      sessionSkill.context.push(message);
+    });
 
     showToast(Locale.Chat.Actions.PinToastContent, {
       text: Locale.Chat.Actions.PinToastAction,
@@ -1932,7 +1938,8 @@ function ChatView() {
                                     chatStore.updateTargetSession(
                                       session,
                                       (session) => {
-                                        const m = session.mask.context
+                                        const sessionSkill = session.mask;
+                                        const m = sessionSkill.context
                                           .concat(session.messages)
                                           .find((m) => m.id === message.id);
                                         if (m) {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -112,6 +112,7 @@ import {
 } from "./ui-lib";
 import { useNavigate } from "react-router-dom";
 import {
+  AUTO_SUBMIT_INPUT,
   CHAT_PAGE_SIZE,
   DEFAULT_TTS_ENGINE,
   ModelProvider,
@@ -1405,6 +1406,9 @@ function ChatView() {
   };
 
   const accessStore = useAccessStore();
+  const pendingAutoSubmitInput =
+    localStorage.getItem(AUTO_SUBMIT_INPUT(session.id)) ?? "";
+  const hasPendingAutoSubmit = pendingAutoSubmitInput.length > 0;
   const [speechStatus, setSpeechStatus] = useState(false);
   const [speechLoading, setSpeechLoading] = useState(false);
 
@@ -1456,14 +1460,14 @@ function ChatView() {
   }, [sessionSkill.context, sessionSkill.hideContext]);
 
   if (
+    !hasPendingAutoSubmit &&
     context.length === 0 &&
-    session.messages.at(0)?.content !== BOT_HELLO.content
+    session.messages.length === 0 &&
+    !accessStore.isAuthorized()
   ) {
-    const copiedHello = Object.assign({}, BOT_HELLO);
-    if (!accessStore.isAuthorized()) {
-      copiedHello.content = Locale.Error.Unauthorized;
-    }
-    context.push(copiedHello);
+    const unauthorizedMessage = Object.assign({}, BOT_HELLO);
+    unauthorizedMessage.content = Locale.Error.Unauthorized;
+    context.push(unauthorizedMessage);
   }
 
   // preview messages
@@ -1615,20 +1619,29 @@ function ChatView() {
 
   // remember unfinished input
   useEffect(() => {
-    // try to load from local storage
-    const key = UNFINISHED_INPUT(session.id);
-    const mayBeUnfinishedInput = localStorage.getItem(key);
-    if (mayBeUnfinishedInput && userInput.length === 0) {
-      setUserInput(mayBeUnfinishedInput);
-      localStorage.removeItem(key);
+    const unfinishedInputKey = UNFINISHED_INPUT(session.id);
+    const autoSubmitInputKey = AUTO_SUBMIT_INPUT(session.id);
+    const pendingAutoSubmitInput = localStorage.getItem(autoSubmitInputKey);
+
+    if (pendingAutoSubmitInput) {
+      localStorage.removeItem(autoSubmitInputKey);
+      setTimeout(() => {
+        doSubmit(pendingAutoSubmitInput);
+      }, 0);
+    } else {
+      const mayBeUnfinishedInput = localStorage.getItem(unfinishedInputKey);
+      if (mayBeUnfinishedInput && userInput.length === 0) {
+        setUserInput(mayBeUnfinishedInput);
+        localStorage.removeItem(unfinishedInputKey);
+      }
     }
 
     const dom = inputRef.current;
     return () => {
-      localStorage.setItem(key, dom?.value ?? "");
+      localStorage.setItem(unfinishedInputKey, dom?.value ?? "");
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [session.id]);
 
   const handlePaste = useCallback(
     async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -121,8 +121,8 @@ import {
   UNFINISHED_INPUT,
 } from "../constant";
 import { Avatar } from "./emoji";
-import { ContextPrompts, MaskAvatar, MaskConfig } from "./mask";
-import { useMaskStore } from "../store/mask";
+import { ContextPrompts, SkillAvatar, SkillConfig } from "./mask";
+import { useSkillStore } from "../store/skill";
 import { ChatCommandPrefix, useChatCommand, useCommand } from "../command";
 import { prettyObject } from "../utils/format";
 import { ExportMessageModal } from "./exporter";
@@ -182,7 +182,8 @@ const MCPAction = () => {
 export function SessionConfigModel(props: { onClose: () => void }) {
   const chatStore = useChatStore();
   const session = chatStore.currentSession();
-  const maskStore = useMaskStore();
+  const sessionSkill = session.mask;
+  const skillStore = useSkillStore();
   const navigate = useNavigate();
   const runtimeModels = useSessionModels();
 
@@ -214,26 +215,26 @@ export function SessionConfigModel(props: { onClose: () => void }) {
             onClick={() => {
               navigate(Path.Skills);
               setTimeout(() => {
-                maskStore.create(session.mask);
+                skillStore.create(sessionSkill);
               }, 500);
             }}
           />,
         ]}
       >
-        <MaskConfig
-          mask={session.mask}
+        <SkillConfig
+          mask={sessionSkill}
           updateMask={(updater) => {
-            const mask = { ...session.mask };
-            updater(mask);
+            const nextSkill = { ...sessionSkill };
+            updater(nextSkill);
             chatStore.updateTargetSession(
               session,
-              (session) => (session.mask = mask),
+              (session) => (session.mask = nextSkill),
             );
           }}
           modelOptions={runtimeModels}
           shouldSyncFromGlobal
           extraListItems={
-            session.mask.modelConfig.sendMemory ? (
+            sessionSkill.modelConfig.sendMemory ? (
               <ListItem
                 className="copyable"
                 title={`${Locale.Memory.Title} (${session.lastSummarizeIndex} of ${session.messages.length})`}
@@ -243,7 +244,7 @@ export function SessionConfigModel(props: { onClose: () => void }) {
               <></>
             )
           }
-        ></MaskConfig>
+        ></SkillConfig>
       </Modal>
     </div>
   );
@@ -256,7 +257,8 @@ function PromptToast(props: {
 }) {
   const chatStore = useChatStore();
   const session = chatStore.currentSession();
-  const context = session.mask.context;
+  const sessionSkill = session.mask;
+  const context = sessionSkill.context;
 
   return (
     <div className={styles["prompt-toast"]} key="prompt-toast">
@@ -528,6 +530,7 @@ export function ChatActions(props: {
   const chatStore = useChatStore();
   const pluginStore = usePluginStore();
   const session = chatStore.currentSession();
+  const sessionSkill = session.mask;
   const { setAttachContents, setUploading } = props;
 
   // switch themes
@@ -546,15 +549,15 @@ export function ChatActions(props: {
   const stopAll = () => ChatControllerPool.stopAll();
 
   // switch model
-  const currentModel = session.mask.modelConfig.model;
+  const currentModel = sessionSkill.modelConfig.model;
   const currentProviderName = (normalizeProviderName(
-    session.mask.modelConfig?.providerName,
+    sessionSkill.modelConfig?.providerName,
   ) ??
-    session.mask.modelConfig?.providerName ??
+    sessionSkill.modelConfig?.providerName ??
     ServiceProvider.OpenAI) as ServiceProvider;
   const sessionCandidateModels = useMemo(
-    () => normalizeModelCandidates(session.mask.candidateModels),
-    [session.mask.candidateModels],
+    () => normalizeModelCandidates(sessionSkill.candidateModels),
+    [sessionSkill.candidateModels],
   );
   const sessionModels = useSessionModels(sessionCandidateModels);
   const hasCandidateModelRestriction = sessionCandidateModels.length > 0;
@@ -615,7 +618,7 @@ export function ChatActions(props: {
   const gptImageQualitys: GptImageQuality[] = ["auto", "high", "medium", "low"];
   const dalle3Styles: DalleStyle[] = ["vivid", "natural"];
   const currentSize =
-    session.mask.modelConfig?.size ?? ("1024x1024" as ModelSize);
+    sessionSkill.modelConfig?.size ?? ("1024x1024" as ModelSize);
   const qualityOptions: ImageQuality[] = isDalle3(currentModel)
     ? dalle3Qualitys
     : isGptImageModel(currentModel)
@@ -624,14 +627,14 @@ export function ChatActions(props: {
   const defaultQuality: ImageQuality = isDalle3(currentModel)
     ? "standard"
     : "auto";
-  const storedQuality = session.mask.modelConfig?.quality as
+  const storedQuality = sessionSkill.modelConfig?.quality as
     | ImageQuality
     | undefined;
   const currentQuality =
     storedQuality && qualityOptions.includes(storedQuality)
       ? storedQuality
       : defaultQuality;
-  const currentStyle = session.mask.modelConfig?.style ?? "vivid";
+  const currentStyle = sessionSkill.modelConfig?.style ?? "vivid";
 
   const isMobileScreen = useMobileScreen();
 
@@ -1071,14 +1074,15 @@ function ChatView() {
 
   const chatStore = useChatStore();
   const session = chatStore.currentSession();
+  const sessionSkill = session.mask;
   const config = useAppConfig();
   const fontSize = config.fontSize;
   const fontFamily = config.fontFamily;
   const isAuthenticated = useAuth();
   const walletAddress = isAuthenticated ? getCurrentAccount() : "";
   const sessionCandidateModels = useMemo(
-    () => normalizeModelCandidates(session.mask.candidateModels),
-    [session.mask.candidateModels],
+    () => normalizeModelCandidates(sessionSkill.candidateModels),
+    [sessionSkill.candidateModels],
   );
   const sessionModels = useSessionModels(sessionCandidateModels);
   const hasCandidateModelRestriction = sessionCandidateModels.length > 0;
@@ -1209,8 +1213,8 @@ function ChatView() {
 
     const hasCurrentModel = sessionModels.some((model) =>
       matchesModelCandidate(model, {
-        model: session.mask.modelConfig.model,
-        providerName: session.mask.modelConfig.providerName,
+        model: sessionSkill.modelConfig.model,
+        providerName: sessionSkill.modelConfig.providerName,
       }),
     );
 
@@ -1255,6 +1259,7 @@ function ChatView() {
 
   useEffect(() => {
     chatStore.updateTargetSession(session, (session) => {
+      const sessionSkill = session.mask;
       const stopTiming = Date.now() - REQUEST_TIMEOUT_MS;
       session.messages.forEach((m) => {
         // check if should stop all stale messages
@@ -1276,9 +1281,9 @@ function ChatView() {
       });
 
       // auto sync mask config from global config
-      const shouldSyncFromGlobal = session.mask.syncGlobalConfig !== false;
+      const shouldSyncFromGlobal = sessionSkill.syncGlobalConfig !== false;
       if (shouldSyncFromGlobal) {
-        session.mask.modelConfig = { ...config.modelConfig };
+        sessionSkill.modelConfig = { ...config.modelConfig };
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1441,8 +1446,8 @@ function ChatView() {
   }
 
   const context: RenderMessage[] = useMemo(() => {
-    return session.mask.hideContext ? [] : session.mask.context.slice();
-  }, [session.mask.context, session.mask.hideContext]);
+    return sessionSkill.hideContext ? [] : sessionSkill.context.slice();
+  }, [sessionSkill.context, sessionSkill.hideContext]);
 
   if (
     context.length === 0 &&
@@ -1948,11 +1953,11 @@ function ChatView() {
                                   {["system"].includes(message.role) ? (
                                     <Avatar avatar="2699-fe0f" />
                                   ) : (
-                                    <MaskAvatar
-                                      avatar={session.mask.avatar}
+                                    <SkillAvatar
+                                      avatar={sessionSkill.avatar}
                                       model={
                                         message.model ||
-                                        session.mask.modelConfig.model
+                                        sessionSkill.modelConfig.model
                                       }
                                     />
                                   )}

--- a/app/components/exporter.tsx
+++ b/app/components/exporter.tsx
@@ -167,18 +167,19 @@ export function MessageExporter() {
 
   const chatStore = useChatStore();
   const session = chatStore.currentSession();
+  const sessionSkill = session.mask;
   const { selection, updateSelection } = useMessageSelector();
   const selectedMessages = useMemo(() => {
     const ret: ChatMessage[] = [];
     if (exportConfig.includeContext) {
-      ret.push(...session.mask.context);
+      ret.push(...sessionSkill.context);
     }
     ret.push(...session.messages.filter((m) => selection.has(m.id)));
     return ret;
   }, [
     exportConfig.includeContext,
     session.messages,
-    session.mask.context,
+    sessionSkill.context,
     selection,
   ]);
   function preview() {
@@ -413,7 +414,7 @@ export function ImagePreviewer(props: {
 }) {
   const chatStore = useChatStore();
   const session = chatStore.currentSession();
-  const mask = session.mask;
+  const sessionSkill = session.mask;
   const config = useAppConfig();
 
   const previewRef = useRef<HTMLDivElement>(null);
@@ -535,14 +536,14 @@ export function ImagePreviewer(props: {
               <SkillAvatar avatar={config.avatar} />
               <span className={styles["icon-space"]}>&</span>
               <SkillAvatar
-                avatar={mask.avatar}
-                model={session.mask.modelConfig.model}
+                avatar={sessionSkill.avatar}
+                model={sessionSkill.modelConfig.model}
               />
             </div>
           </div>
           <div>
             <div className={styles["chat-info-item"]}>
-              {Locale.Exporter.Model}: {mask.modelConfig.model}
+              {Locale.Exporter.Model}: {sessionSkill.modelConfig.model}
             </div>
             <div className={styles["chat-info-item"]}>
               {Locale.Exporter.Messages}: {props.messages.length}
@@ -569,8 +570,8 @@ export function ImagePreviewer(props: {
                   <Avatar avatar={config.avatar}></Avatar>
                 ) : (
                   <SkillAvatar
-                    avatar={session.mask.avatar}
-                    model={m.model || session.mask.modelConfig.model}
+                    avatar={sessionSkill.avatar}
+                    model={m.model || sessionSkill.modelConfig.model}
                   />
                 )}
               </div>

--- a/app/components/exporter.tsx
+++ b/app/components/exporter.tsx
@@ -39,7 +39,7 @@ import { getClientConfig } from "../config/client";
 import { type ClientApi, getClientApi } from "../client/api";
 import { isDesktopAppRuntime, saveWithDialog, writeFile } from "../tauri";
 import { getMessageTextContent } from "../utils";
-import { MaskAvatar } from "./mask";
+import { SkillAvatar } from "./mask";
 import clsx from "clsx";
 
 const Markdown = dynamic(async () => (await import("./markdown")).Markdown, {
@@ -532,9 +532,9 @@ export function ImagePreviewer(props: {
               github.com/yeying-community/chat
             </div>
             <div className={styles["icons"]}>
-              <MaskAvatar avatar={config.avatar} />
+              <SkillAvatar avatar={config.avatar} />
               <span className={styles["icon-space"]}>&</span>
-              <MaskAvatar
+              <SkillAvatar
                 avatar={mask.avatar}
                 model={session.mask.modelConfig.model}
               />
@@ -568,7 +568,7 @@ export function ImagePreviewer(props: {
                 {m.role === "user" ? (
                   <Avatar avatar={config.avatar}></Avatar>
                 ) : (
-                  <MaskAvatar
+                  <SkillAvatar
                     avatar={session.mask.avatar}
                     model={m.model || session.mask.modelConfig.model}
                   />

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -29,7 +29,7 @@ import { useAppConfig } from "../store/config";
 import { AuthPage } from "./auth";
 import { getClientConfig } from "../config/client";
 import { getRouterClientApi } from "../client/api";
-import { useAccessStore, useMaskProviderModelsStore } from "../store";
+import { useAccessStore, useSkillProviderModelsStore } from "../store";
 import clsx from "clsx";
 import { initializeMcpSystem, isMcpEnabled } from "../mcp/actions";
 import {
@@ -343,7 +343,7 @@ function Screen() {
 
 export function useLoadData() {
   const mergeModels = useAppConfig((state) => state.mergeModels);
-  const setMaskProviderModels = useMaskProviderModelsStore(
+  const setSkillProviderModels = useSkillProviderModelsStore(
     (state) => state.setModels,
   );
   const loadModels = useCallback(async () => {
@@ -353,8 +353,8 @@ export function useLoadData() {
       api.llm.providerModels?.() ?? Promise.resolve([]),
     ]);
     mergeModels(models);
-    setMaskProviderModels(providerModels);
-  }, [mergeModels, setMaskProviderModels]);
+    setSkillProviderModels(providerModels);
+  }, [mergeModels, setSkillProviderModels]);
 
   useEffect(() => {
     loadModels().catch((error) => {

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -108,7 +108,7 @@ const NewChat = dynamic(async () => (await import("./new-chat")).NewChat, {
   loading: () => <Loading noLogo />,
 });
 
-const MaskPage = dynamic(async () => (await import("./mask")).MaskPage, {
+const SkillPage = dynamic(async () => (await import("./mask")).SkillPage, {
   loading: () => <Loading noLogo />,
 });
 
@@ -314,8 +314,8 @@ function Screen() {
             <Routes>
               <Route path={Path.Home} element={<Chat />} />
               <Route path={Path.NewChat} element={<NewChat />} />
-              <Route path={Path.Skills} element={<MaskPage />} />
-              <Route path={Path.Masks} element={<MaskPage />} />
+              <Route path={Path.Skills} element={<SkillPage />} />
+              <Route path={Path.Masks} element={<SkillPage />} />
               <Route path={Path.Plugins} element={<PluginPage />} />
               <Route path={Path.SearchChat} element={<SearchChat />} />
               <Route path={Path.Chat} element={<Chat />} />

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -13,7 +13,12 @@ import EyeIcon from "../icons/eye.svg";
 import CopyIcon from "../icons/copy.svg";
 import DragIcon from "../icons/drag.svg";
 
-import { DEFAULT_MASK_AVATAR, Mask, useMaskStore } from "../store/mask";
+import {
+  DEFAULT_MASK_AVATAR,
+  Mask,
+  getLaunchableSkills,
+  useSkillStore,
+} from "../store/skill";
 import {
   ChatMessage,
   createMessage,
@@ -80,7 +85,7 @@ function isEmojiUnified(avatar?: string) {
   return !!avatar && EMOJI_UNIFIED_RE.test(avatar);
 }
 
-export function MaskAvatar(props: { avatar: string; model?: ModelType }) {
+export function SkillAvatar(props: { avatar: string; model?: ModelType }) {
   const config = useAppConfig();
   const model = props.model || config.modelConfig.model;
   const useEmoji =
@@ -91,7 +96,9 @@ export function MaskAvatar(props: { avatar: string; model?: ModelType }) {
   return useEmoji ? <Avatar avatar={props.avatar} /> : <Avatar model={model} />;
 }
 
-export function MaskConfig(props: {
+export const MaskAvatar = SkillAvatar;
+
+export function SkillConfig(props: {
   mask: Mask;
   updateMask: Updater<Mask>;
   extraListItems?: ReactNode;
@@ -102,7 +109,7 @@ export function MaskConfig(props: {
   const [showPicker, setShowPicker] = useState(false);
   const [showCandidateModelSelector, setShowCandidateModelSelector] =
     useState(false);
-  const maskProviderModels = useMaskProviderModels();
+  const skillProviderModels = useMaskProviderModels();
   const selectedCandidateModels = useMemo(
     () => normalizeModelCandidates(props.mask.candidateModels),
     [props.mask.candidateModels],
@@ -114,22 +121,24 @@ export function MaskConfig(props: {
       ),
     [selectedCandidateModels],
   );
-  const baseModelOptions = props.modelOptions ?? maskProviderModels;
-  const maskModelOptions = useMemo(() => {
+  const baseModelOptions = props.modelOptions ?? skillProviderModels;
+  const skillModelOptions = useMemo(() => {
     if (selectedCandidateModels.length === 0) {
       return baseModelOptions;
     }
     return filterModelsByCandidates(baseModelOptions, selectedCandidateModels);
   }, [baseModelOptions, selectedCandidateModels]);
   const candidateModelSummary =
-    maskProviderModels.length === 0
+    skillProviderModels.length === 0
       ? Locale.SearchChat.Page.Loading
       : selectedCandidateModels.length === 0
-        ? "No restriction"
-        : `${selectedCandidateModels.length} models selected`;
+        ? Locale.Mask.Config.CandidateModels.SummaryNone
+        : Locale.Mask.Config.CandidateModels.SummarySelected(
+            selectedCandidateModels.length,
+          );
   const candidateModelSelectorItems = useMemo(
     () =>
-      maskProviderModels.map((model) => ({
+      skillProviderModels.map((model) => ({
         title: `${model.displayName}${
           model.provider?.providerName
             ? ` (${model.provider.providerName})`
@@ -140,7 +149,7 @@ export function MaskConfig(props: {
           providerName: model.provider?.id ?? model.provider?.providerName,
         }),
       })),
-    [maskProviderModels],
+    [skillProviderModels],
   );
 
   const readonlyContextMarkdown = props.mask.context
@@ -162,9 +171,9 @@ export function MaskConfig(props: {
     });
   };
 
-  const copyMaskLink = () => {
-    const maskLink = `${location.protocol}//${location.host}/#${Path.NewChat}?mask=${props.mask.id}`;
-    copyToClipboard(maskLink);
+  const copySkillLink = () => {
+    const skillLink = `${location.protocol}//${location.host}/#${Path.NewChat}?mask=${props.mask.id}`;
+    copyToClipboard(skillLink);
   };
 
   const globalConfig = useAppConfig();
@@ -235,7 +244,7 @@ export function MaskConfig(props: {
               onClick={() => setShowPicker(true)}
               style={{ cursor: "pointer" }}
             >
-              <MaskAvatar
+              <SkillAvatar
                 avatar={props.mask.avatar}
                 model={props.mask.modelConfig.model}
               />
@@ -255,11 +264,11 @@ export function MaskConfig(props: {
           ></input>
         </ListItem>
         <ListItem
-          title="Candidate Models"
-          subTitle="Only these models can be used by chat sessions created from this mask"
+          title={Locale.Mask.Config.CandidateModels.Title}
+          subTitle={Locale.Mask.Config.CandidateModels.SubTitle}
         >
           <input
-            aria-label="Candidate Models"
+            aria-label={Locale.Mask.Config.CandidateModels.Title}
             type="text"
             readOnly
             value={candidateModelSummary}
@@ -326,7 +335,7 @@ export function MaskConfig(props: {
               aria={Locale.Mask.Config.Share.Title}
               icon={<CopyIcon />}
               text={Locale.Mask.Config.Share.Action}
-              onClick={copyMaskLink}
+              onClick={copySkillLink}
             />
           </ListItem>
         ) : null}
@@ -365,7 +374,7 @@ export function MaskConfig(props: {
         <ModelConfigList
           modelConfig={{ ...props.mask.modelConfig }}
           updateConfig={updateConfig}
-          modelOptions={maskModelOptions}
+          modelOptions={skillModelOptions}
           strictModelSelection
         />
         {props.extraListItems}
@@ -396,6 +405,8 @@ export function MaskConfig(props: {
     </>
   );
 }
+
+export const MaskConfig = SkillConfig;
 
 function ContextPromptItem(props: {
   index: number;
@@ -582,32 +593,32 @@ export function ContextPrompts(props: {
 export function MaskPage() {
   const navigate = useNavigate();
 
-  const maskStore = useMaskStore();
+  const skillStore = useSkillStore();
   const chatStore = useChatStore();
 
-  const filterLang = maskStore.language;
+  const filterLang = skillStore.language;
 
-  const allMasks = maskStore
-    .getAll()
-    .filter((m) => !filterLang || m.lang === filterLang);
+  const allSkills = getLaunchableSkills(skillStore.getAll()).filter(
+    (m) => !filterLang || m.lang === filterLang,
+  );
 
   const [searchText, setSearchText] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("");
   const categories = useMemo(
     () =>
       Array.from(
-        new Set(allMasks.map((m) => m.category).filter(Boolean) as string[]),
+        new Set(allSkills.map((m) => m.category).filter(Boolean) as string[]),
       ),
-    [allMasks],
+    [allSkills],
   );
   useEffect(() => {
     if (selectedCategory && !categories.includes(selectedCategory)) {
       setSelectedCategory("");
     }
   }, [categories, selectedCategory]);
-  const masks = useMemo(() => {
+  const skills = useMemo(() => {
     const keyword = searchText.trim().toLowerCase();
-    return allMasks.filter((m) => {
+    return allSkills.filter((m) => {
       const matchCategory =
         !selectedCategory || m.category === selectedCategory;
       const haystack = [
@@ -621,16 +632,16 @@ export function MaskPage() {
         .toLowerCase();
       return matchCategory && (!keyword || haystack.includes(keyword));
     });
-  }, [allMasks, searchText, selectedCategory]);
+  }, [allSkills, searchText, selectedCategory]);
 
-  const [editingMaskId, setEditingMaskId] = useState<string | undefined>();
-  const editingMask =
-    maskStore.get(editingMaskId) ?? BUILTIN_SKILL_STORE.get(editingMaskId);
-  const closeMaskModal = () => setEditingMaskId(undefined);
+  const [editingSkillId, setEditingSkillId] = useState<string | undefined>();
+  const editingSkill =
+    skillStore.get(editingSkillId) ?? BUILTIN_SKILL_STORE.get(editingSkillId);
+  const closeSkillModal = () => setEditingSkillId(undefined);
 
   const downloadAll = () => {
     downloadAs(
-      JSON.stringify(masks.filter((v) => !v.builtin)),
+      JSON.stringify(skills.filter((v) => !v.builtin)),
       FileName.Skills,
     );
   };
@@ -640,16 +651,16 @@ export function MaskPage() {
       try {
         const importMasks = JSON.parse(content);
         if (Array.isArray(importMasks)) {
-          for (const mask of importMasks) {
-            if (mask.name) {
-              maskStore.create(mask);
+          for (const skill of importMasks) {
+            if (skill.name) {
+              skillStore.create(skill);
             }
           }
           return;
         }
         //if the content is a single mask.
         if (importMasks.name) {
-          maskStore.create(importMasks);
+          skillStore.create(importMasks);
         }
       } catch {}
     });
@@ -664,7 +675,7 @@ export function MaskPage() {
               {Locale.Mask.Page.Title}
             </div>
             <div className="window-header-submai-title">
-              {Locale.Mask.Page.SubTitle(allMasks.length)}
+              {Locale.Mask.Page.SubTitle(allSkills.length)}
             </div>
           </div>
 
@@ -710,9 +721,9 @@ export function MaskPage() {
               onChange={(e) => {
                 const value = e.currentTarget.value;
                 if (value === Locale.Settings.Lang.All) {
-                  maskStore.setLanguage(undefined);
+                  skillStore.setLanguage(undefined);
                 } else {
-                  maskStore.setLanguage(value as Lang);
+                  skillStore.setLanguage(value as Lang);
                 }
               }}
             >
@@ -732,8 +743,8 @@ export function MaskPage() {
               text={Locale.Mask.Page.Create}
               bordered
               onClick={() => {
-                const createdMask = maskStore.create();
-                setEditingMaskId(createdMask.id);
+                const createdSkill = skillStore.create();
+                setEditingSkillId(createdSkill.id);
               }}
             />
           </div>
@@ -766,11 +777,14 @@ export function MaskPage() {
           )}
 
           <div className={styles["mask-grid"]}>
-            {masks.map((m) => (
+            {skills.map((m) => (
               <div className={styles["mask-item"]} key={m.id}>
                 <div className={styles["mask-header"]}>
                   <div className={styles["mask-icon"]}>
-                    <MaskAvatar avatar={m.avatar} model={m.modelConfig.model} />
+                    <SkillAvatar
+                      avatar={m.avatar}
+                      model={m.modelConfig.model}
+                    />
                   </div>
                   <div className={styles["mask-title"]}>
                     <div className={styles["mask-name"]}>{m.name}</div>
@@ -814,13 +828,13 @@ export function MaskPage() {
                     <IconButton
                       icon={<EyeIcon />}
                       text={Locale.Mask.Item.View}
-                      onClick={() => setEditingMaskId(m.id)}
+                      onClick={() => setEditingSkillId(m.id)}
                     />
                   ) : (
                     <IconButton
                       icon={<EditIcon />}
                       text={Locale.Mask.Item.Edit}
-                      onClick={() => setEditingMaskId(m.id)}
+                      onClick={() => setEditingSkillId(m.id)}
                     />
                   )}
                   {!m.builtin && (
@@ -829,7 +843,7 @@ export function MaskPage() {
                       text={Locale.Mask.Item.Delete}
                       onClick={async () => {
                         if (await showConfirm(Locale.Mask.Item.DeleteConfirm)) {
-                          maskStore.delete(m.id);
+                          skillStore.delete(m.id);
                         }
                       }}
                     />
@@ -837,7 +851,7 @@ export function MaskPage() {
                 </div>
               </div>
             ))}
-            {masks.length === 0 && (
+            {skills.length === 0 && (
               <div className={styles["mask-empty"]}>
                 {Locale.Mask.Page.Empty}
               </div>
@@ -846,11 +860,11 @@ export function MaskPage() {
         </div>
       </div>
 
-      {editingMask && (
+      {editingSkill && (
         <div className="modal-mask">
           <Modal
-            title={Locale.Mask.EditModal.Title(editingMask?.builtin)}
-            onClose={closeMaskModal}
+            title={Locale.Mask.EditModal.Title(editingSkill?.builtin)}
+            onClose={closeSkillModal}
             actions={[
               <IconButton
                 icon={<DownloadIcon />}
@@ -859,8 +873,8 @@ export function MaskPage() {
                 bordered
                 onClick={() =>
                   downloadAs(
-                    JSON.stringify(editingMask),
-                    `${editingMask.name}.json`,
+                    JSON.stringify(editingSkill),
+                    `${editingSkill.name}.json`,
                   )
                 }
               />,
@@ -871,18 +885,18 @@ export function MaskPage() {
                 text={Locale.Mask.EditModal.Clone}
                 onClick={() => {
                   navigate(Path.Skills);
-                  maskStore.create(editingMask);
-                  setEditingMaskId(undefined);
+                  skillStore.create(editingSkill);
+                  setEditingSkillId(undefined);
                 }}
               />,
             ]}
           >
-            <MaskConfig
-              mask={editingMask}
+            <SkillConfig
+              mask={editingSkill}
               updateMask={(updater) =>
-                maskStore.updateMask(editingMaskId!, updater)
+                skillStore.updateMask(editingSkillId!, updater)
               }
-              readonly={editingMask.builtin}
+              readonly={editingSkill.builtin}
             />
           </Modal>
         </div>

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -14,8 +14,8 @@ import CopyIcon from "../icons/copy.svg";
 import DragIcon from "../icons/drag.svg";
 
 import {
-  DEFAULT_MASK_AVATAR,
-  Mask,
+  DEFAULT_SKILL_AVATAR,
+  Skill,
   getLaunchableSkills,
   useSkillStore,
 } from "../store/skill";
@@ -90,7 +90,7 @@ export function SkillAvatar(props: { avatar: string; model?: ModelType }) {
   const model = props.model || config.modelConfig.model;
   const useEmoji =
     props.avatar &&
-    props.avatar !== DEFAULT_MASK_AVATAR &&
+    props.avatar !== DEFAULT_SKILL_AVATAR &&
     isEmojiUnified(props.avatar);
 
   return useEmoji ? <Avatar avatar={props.avatar} /> : <Avatar model={model} />;
@@ -99,20 +99,21 @@ export function SkillAvatar(props: { avatar: string; model?: ModelType }) {
 export const MaskAvatar = SkillAvatar;
 
 export function SkillConfig(props: {
-  mask: Mask;
-  updateMask: Updater<Mask>;
+  mask: Skill;
+  updateMask: Updater<Skill>;
   extraListItems?: ReactNode;
   readonly?: boolean;
   shouldSyncFromGlobal?: boolean;
   modelOptions?: LLMModel[];
 }) {
+  const skill = props.mask;
   const [showPicker, setShowPicker] = useState(false);
   const [showCandidateModelSelector, setShowCandidateModelSelector] =
     useState(false);
   const skillProviderModels = useMaskProviderModels();
   const selectedCandidateModels = useMemo(
-    () => normalizeModelCandidates(props.mask.candidateModels),
-    [props.mask.candidateModels],
+    () => normalizeModelCandidates(skill.candidateModels),
+    [skill.candidateModels],
   );
   const selectedCandidateValues = useMemo(
     () =>
@@ -152,7 +153,7 @@ export function SkillConfig(props: {
     [skillProviderModels],
   );
 
-  const readonlyContextMarkdown = props.mask.context
+  const readonlyContextMarkdown = skill.context
     .map((message, index) => {
       const content = getMessageTextContent(message).trim();
       return `### ${index + 1}. ${message.role}\n\n${content || "_empty_"}`;
@@ -162,7 +163,7 @@ export function SkillConfig(props: {
   const updateConfig = (updater: (config: ModelConfig) => void) => {
     if (props.readonly) return;
 
-    const config = { ...props.mask.modelConfig };
+    const config = { ...skill.modelConfig };
     updater(config);
     props.updateMask((mask) => {
       mask.modelConfig = config;
@@ -172,7 +173,7 @@ export function SkillConfig(props: {
   };
 
   const copySkillLink = () => {
-    const skillLink = `${location.protocol}//${location.host}/#${Path.NewChat}?mask=${props.mask.id}`;
+    const skillLink = `${location.protocol}//${location.host}/#${Path.NewChat}?skill=${skill.id}`;
     copyToClipboard(skillLink);
   };
 
@@ -182,25 +183,21 @@ export function SkillConfig(props: {
     <>
       {props.readonly ? (
         <List>
-          {props.mask.category && (
-            <ListItem
-              title="Category"
-              subTitle={props.mask.category}
-              vertical
-            />
+          {skill.category && (
+            <ListItem title="Category" subTitle={skill.category} vertical />
           )}
-          {props.mask.description && (
+          {skill.description && (
             <ListItem title="Description" vertical>
               <div className={styles["mask-readonly-section"]}>
-                <Markdown content={props.mask.description} />
+                <Markdown content={skill.description} />
               </div>
             </ListItem>
           )}
-          {!!props.mask.starters?.length && (
+          {!!skill.starters?.length && (
             <ListItem title="Recommended Starters" vertical>
               <div className={styles["mask-readonly-section"]}>
                 <Markdown
-                  content={props.mask.starters
+                  content={skill.starters
                     .map((starter) => `- ${starter}`)
                     .join("\n")}
                 />
@@ -215,9 +212,9 @@ export function SkillConfig(props: {
         </List>
       ) : (
         <ContextPrompts
-          context={props.mask.context}
+          context={skill.context}
           updateContext={(updater) => {
-            const context = props.mask.context.slice();
+            const context = skill.context.slice();
             updater(context);
             props.updateMask((mask) => (mask.context = context));
           }}
@@ -245,8 +242,8 @@ export function SkillConfig(props: {
               style={{ cursor: "pointer" }}
             >
               <SkillAvatar
-                avatar={props.mask.avatar}
-                model={props.mask.modelConfig.model}
+                avatar={skill.avatar}
+                model={skill.modelConfig.model}
               />
             </div>
           </Popover>
@@ -255,7 +252,7 @@ export function SkillConfig(props: {
           <input
             aria-label={Locale.Mask.Config.Name}
             type="text"
-            value={props.mask.name}
+            value={skill.name}
             onInput={(e) =>
               props.updateMask((mask) => {
                 mask.name = e.currentTarget.value;
@@ -282,7 +279,7 @@ export function SkillConfig(props: {
           <input
             aria-label={Locale.Mask.Config.HideContext.Title}
             type="checkbox"
-            checked={props.mask.hideContext}
+            checked={skill.hideContext}
             onChange={(e) => {
               props.updateMask((mask) => {
                 mask.hideContext = e.currentTarget.checked;
@@ -299,7 +296,7 @@ export function SkillConfig(props: {
             <input
               aria-label={Locale.Mask.Config.Artifacts.Title}
               type="checkbox"
-              checked={props.mask.enableArtifacts !== false}
+              checked={skill.enableArtifacts !== false}
               onChange={(e) => {
                 props.updateMask((mask) => {
                   mask.enableArtifacts = e.currentTarget.checked;
@@ -316,7 +313,7 @@ export function SkillConfig(props: {
             <input
               aria-label={Locale.Mask.Config.CodeFold.Title}
               type="checkbox"
-              checked={props.mask.enableCodeFold !== false}
+              checked={skill.enableCodeFold !== false}
               onChange={(e) => {
                 props.updateMask((mask) => {
                   mask.enableCodeFold = e.currentTarget.checked;
@@ -348,7 +345,7 @@ export function SkillConfig(props: {
             <input
               aria-label={Locale.Mask.Config.Sync.Title}
               type="checkbox"
-              checked={props.mask.syncGlobalConfig !== false}
+              checked={skill.syncGlobalConfig !== false}
               onChange={async (e) => {
                 const checked = e.currentTarget.checked;
                 if (
@@ -372,7 +369,7 @@ export function SkillConfig(props: {
 
       <List>
         <ModelConfigList
-          modelConfig={{ ...props.mask.modelConfig }}
+          modelConfig={{ ...skill.modelConfig }}
           updateConfig={updateConfig}
           modelOptions={skillModelOptions}
           strictModelSelection

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -590,7 +590,7 @@ export function ContextPrompts(props: {
   );
 }
 
-export function MaskPage() {
+export function SkillPage() {
   const navigate = useNavigate();
 
   const skillStore = useSkillStore();
@@ -658,7 +658,7 @@ export function MaskPage() {
           }
           return;
         }
-        //if the content is a single mask.
+        // If the file contains a single skill, import it directly.
         if (importMasks.name) {
           skillStore.create(importMasks);
         }
@@ -904,3 +904,5 @@ export function MaskPage() {
     </ErrorBoundary>
   );
 }
+
+export const MaskPage = SkillPage;

--- a/app/components/message-selector.tsx
+++ b/app/components/message-selector.tsx
@@ -75,6 +75,7 @@ export function MessageSelector(props: {
   const LATEST_COUNT = 4;
   const chatStore = useChatStore();
   const session = chatStore.currentSession();
+  const sessionSkill = session.mask;
   const isValid = (m: ChatMessage) => m.content && !m.isError && !m.streaming;
   const allMessages = useMemo(() => {
     let startIndex = Math.max(0, session.clearContextIndex ?? 0);
@@ -212,8 +213,8 @@ export function MessageSelector(props: {
                   <Avatar avatar={config.avatar}></Avatar>
                 ) : (
                   <SkillAvatar
-                    avatar={session.mask.avatar}
-                    model={m.model || session.mask.modelConfig.model}
+                    avatar={sessionSkill.avatar}
+                    model={m.model || sessionSkill.modelConfig.model}
                   />
                 )}
               </div>

--- a/app/components/message-selector.tsx
+++ b/app/components/message-selector.tsx
@@ -3,7 +3,7 @@ import { ChatMessage, useAppConfig, useChatStore } from "../store";
 import { Updater } from "../typing";
 import { IconButton } from "./button";
 import { Avatar } from "./emoji";
-import { MaskAvatar } from "./mask";
+import { SkillAvatar } from "./mask";
 import Locale from "../locales";
 
 import styles from "./message-selector.module.scss";
@@ -211,7 +211,7 @@ export function MessageSelector(props: {
                 {m.role === "user" ? (
                   <Avatar avatar={config.avatar}></Avatar>
                 ) : (
-                  <MaskAvatar
+                  <SkillAvatar
                     avatar={session.mask.avatar}
                     model={m.model || session.mask.modelConfig.model}
                   />

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -1,4 +1,4 @@
-import { Path, UNFINISHED_INPUT } from "../constant";
+import { AUTO_SUBMIT_INPUT, Path, UNFINISHED_INPUT } from "../constant";
 import { IconButton } from "./button";
 import styles from "./new-chat.module.scss";
 
@@ -83,16 +83,18 @@ export function NewChat() {
   const navigate = useNavigate();
 
   const startChat = (skill?: Skill, initialInput = "") => {
-    setTimeout(() => {
-      if (chatStore.newSession(skill) !== false) {
-        const input = initialInput.trim();
-        const session = useChatStore.getState().sessions[0];
-        if (input && session?.id) {
-          localStorage.setItem(UNFINISHED_INPUT(session.id), input);
-        }
-        navigate(Path.Chat);
-      }
-    }, 10);
+    if (chatStore.newSession(skill) === false) {
+      return;
+    }
+
+    const input = initialInput.trim();
+    const session = useChatStore.getState().sessions[0];
+    if (input && session?.id) {
+      localStorage.removeItem(UNFINISHED_INPUT(session.id));
+      localStorage.setItem(AUTO_SUBMIT_INPUT(session.id), input);
+    }
+
+    navigate(Path.Chat);
   };
 
   const startDraftChat = () => startChat(undefined, draft);

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -8,11 +8,11 @@ import ImageIcon from "../icons/image.svg";
 import SendWhiteIcon from "../icons/send-white.svg";
 
 import { useNavigate } from "react-router-dom";
-import { Skill, useSkillStore } from "../store/skill";
+import { getLaunchableSkills, Skill, useSkillStore } from "../store/skill";
 import Locale from "../locales";
 import { useChatStore } from "../store";
 import { useSdStore } from "../store/sd";
-import { MaskAvatar } from "./mask";
+import { SkillAvatar } from "./mask";
 import { useCommand } from "../command";
 import { BUILTIN_SKILL_STORE } from "../skills";
 import clsx from "clsx";
@@ -22,7 +22,7 @@ import { safeLocalStorage } from "../utils";
 function SkillItem(props: { skill: Skill; onClick?: () => void }) {
   return (
     <div className={styles["mask"]} onClick={props.onClick}>
-      <MaskAvatar
+      <SkillAvatar
         avatar={props.skill.avatar}
         model={props.skill.modelConfig.model}
       />
@@ -43,7 +43,10 @@ export function NewChat() {
   const sdStore = useSdStore();
   const [draft, setDraft] = useState("");
 
-  const skills = skillStore.getAll();
+  const skills = useMemo(
+    () => getLaunchableSkills(skillStore.getAll()),
+    [skillStore],
+  );
   const recentSkills = useMemo(() => {
     const seen = new Set<string>();
     return chatStore.sessions

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -117,6 +117,14 @@ export function NewChat() {
         console.error("[New Chat] failed to create chat from skill id=", id);
       }
     },
+    skill: (id) => {
+      try {
+        const skill = skillStore.get(id) ?? BUILTIN_SKILL_STORE.get(id);
+        startChat(skill ?? undefined);
+      } catch {
+        console.error("[New Chat] failed to create chat from skill id=", id);
+      }
+    },
   });
 
   return (

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -634,7 +634,7 @@ function SyncItems() {
       chat: sessions.length,
       message: messageCount,
       prompt: Object.keys(promptStore.prompts).length,
-      mask: Object.keys(skillStore.skills).length,
+      skill: Object.keys(skillStore.skills).length,
     };
   }, [chatStore.sessions, skillStore.skills, promptStore.prompts]);
 

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -114,6 +114,7 @@ export const ACCESS_CODE_PREFIX = "nk-";
 
 export const LAST_INPUT_KEY = "last-input";
 export const UNFINISHED_INPUT = (id: string) => "unfinished-input-" + id;
+export const AUTO_SUBMIT_INPUT = (id: string) => "auto-submit-input-" + id;
 
 export const STORAGE_KEY = "chatgpt-next-web";
 

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -284,7 +284,8 @@ const cn = {
 
       LocalState: "本地数据",
       Overview: (overview: any) => {
-        return `${overview.chat} 次对话，${overview.message} 条消息，${overview.prompt} 条提示词，${overview.mask} 个技能`;
+        const skillCount = overview.skill ?? overview.mask ?? 0;
+        return `${overview.chat} 次对话，${overview.message} 条消息，${overview.prompt} 条提示词，${skillCount} 个技能`;
       },
       ImportFailed: "导入失败",
     },

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -834,6 +834,12 @@ const cn = {
     Config: {
       Avatar: "角色头像",
       Name: "角色名称",
+      CandidateModels: {
+        Title: "候选模型",
+        SubTitle: "通过这个技能创建的会话，仅可使用这些模型",
+        SummaryNone: "不限制",
+        SummarySelected: (count: number) => `已选择 ${count} 个模型`,
+      },
       Sync: {
         Title: "使用全局设置",
         SubTitle: "当前对话是否使用全局模型设置",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -288,7 +288,8 @@ const en: LocaleType = {
 
       LocalState: "Local Data",
       Overview: (overview: any) => {
-        return `${overview.chat} chats，${overview.message} messages，${overview.prompt} prompts，${overview.mask} skills`;
+        const skillCount = overview.skill ?? overview.mask ?? 0;
+        return `${overview.chat} chats，${overview.message} messages，${overview.prompt} prompts，${skillCount} skills`;
       },
       ImportFailed: "Failed to import from file",
     },

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -848,6 +848,13 @@ const en: LocaleType = {
     Config: {
       Avatar: "Bot Avatar",
       Name: "Bot Name",
+      CandidateModels: {
+        Title: "Candidate Models",
+        SubTitle:
+          "Chat sessions created from this skill can only use these models",
+        SummaryNone: "No restriction",
+        SummarySelected: (count: number) => `${count} models selected`,
+      },
       Sync: {
         Title: "Use Global Config",
         SubTitle: "Use global config in this chat",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -47,7 +47,7 @@ import {
   normalizeModelCandidates,
   normalizeProviderName,
 } from "../utils/model";
-import { createEmptyMask, Mask } from "./mask";
+import { createEmptySkill, Skill } from "./skill";
 import { executeMcpAction, getAllTools, isMcpEnabled } from "../mcp/actions";
 import { extractMcpJson, isMcpJson } from "../mcp/utils";
 import { isValidUcanAuthorization } from "../plugins/wallet";
@@ -111,7 +111,7 @@ export interface ChatSession {
   lastSummarizeIndex: number;
   clearContextIndex?: number;
 
-  mask: Mask;
+  mask: Skill;
 }
 
 export const DEFAULT_TOPIC = Locale.Store.DefaultTopic;
@@ -135,7 +135,7 @@ function createEmptySession(): ChatSession {
     lastUpdate: Date.now(),
     lastSummarizeIndex: 0,
 
-    mask: createEmptyMask(),
+    mask: createEmptySkill(),
   };
 }
 
@@ -436,22 +436,22 @@ export const useChatStore = createPersistStore(
         });
       },
 
-      newSession(mask?: Mask) {
+      newSession(skill?: Skill) {
         const session = createEmptySession();
 
-        if (mask) {
+        if (skill) {
           const config = useAppConfig.getState();
           const accessStore = useAccessStore.getState();
           const globalModelConfig = config.modelConfig;
-          const shouldSyncFromGlobal = mask.syncGlobalConfig !== false;
+          const shouldSyncFromGlobal = skill.syncGlobalConfig !== false;
           const candidateModels = normalizeModelCandidates(
-            mask.candidateModels,
+            skill.candidateModels,
           );
           const nextModelConfig = shouldSyncFromGlobal
             ? { ...globalModelConfig }
             : {
                 ...globalModelConfig,
-                ...mask.modelConfig,
+                ...skill.modelConfig,
               };
           const runtimeModels = collectModelsWithDefaultModel(
             config.models,
@@ -483,12 +483,12 @@ export const useChatStore = createPersistStore(
             );
 
           session.mask = {
-            ...mask,
+            ...skill,
             candidateModels,
             syncGlobalConfig: shouldSyncFromGlobal,
             modelConfig: nextModelConfig,
           };
-          session.topic = mask.name;
+          session.topic = skill.name;
 
           if (hasCandidateModelRestriction && !hasCurrentModel) {
             showToast("技能默认模型当前不可用，请先选择一个可用模型");

--- a/app/store/mask-provider-models.ts
+++ b/app/store/mask-provider-models.ts
@@ -7,10 +7,12 @@ type MaskProviderModelsStore = {
   clear: () => void;
 };
 
-export const useMaskProviderModelsStore = create<MaskProviderModelsStore>(
+export const useSkillProviderModelsStore = create<MaskProviderModelsStore>(
   (set) => ({
     models: [],
     setModels: (models) => set({ models }),
     clear: () => set({ models: [] }),
   }),
 );
+
+export const useMaskProviderModelsStore = useSkillProviderModelsStore;

--- a/app/store/mask.ts
+++ b/app/store/mask.ts
@@ -5,6 +5,9 @@ export {
   DEFAULT_SKILL_STATE,
   createEmptyMask,
   createEmptySkill,
+  getBuiltinSkillsForLang,
+  getLaunchableSkills,
+  isLaunchableSkill,
   useMaskStore,
   useSkillStore,
 } from "./skill";

--- a/app/store/skill.ts
+++ b/app/store/skill.ts
@@ -53,6 +53,43 @@ export const createEmptySkill = () =>
     plugin: [],
   }) as Skill;
 
+function withBuiltinSkillConfig(skill: BuiltinSkill, modelConfig: ModelConfig) {
+  return {
+    ...skill,
+    modelConfig: {
+      ...modelConfig,
+      ...skill.modelConfig,
+    },
+  } as Skill;
+}
+
+export function getBuiltinSkillsForLang(
+  lang = getLang(),
+  modelConfig = useAppConfig.getState().modelConfig,
+) {
+  const seen = new Set<string>();
+  return BUILTIN_SKILLS.filter((item) => {
+    if (item.lang !== lang || seen.has(item.name)) return false;
+    seen.add(item.name);
+    return true;
+  }).map((skill) => withBuiltinSkillConfig(skill, modelConfig));
+}
+
+export function isLaunchableSkill(skill: Skill) {
+  if (skill.builtin) return true;
+
+  return Boolean(
+    skill.description ||
+    skill.category ||
+    skill.starters?.length ||
+    skill.plugin?.length,
+  );
+}
+
+export function getLaunchableSkills(skills: Skill[]) {
+  return skills.filter(isLaunchableSkill);
+}
+
 export const useSkillStore = createPersistStore(
   { ...DEFAULT_SKILL_STATE },
 
@@ -108,36 +145,9 @@ export const useSkillStore = createPersistStore(
       );
       const config = useAppConfig.getState();
       if (config.hideBuiltinSkills) return userSkills;
-      // 根据当前环境设置的语言过滤出对应的内置技能
-      // BUILTIN_SKILLS.filter()
-      // const DEFAULT_LANG = "en"; 默认语言是英文，可以在设置里修改语言
-      const lang = getLang();
-      // lang=cn
-      const currentSkills = BUILTIN_SKILLS.filter((item) => item.lang === lang);
-
-      // 去除重复
-      const uniqueCurrentSkills = currentSkills.reduce<BuiltinSkill[]>(
-        (skills, current) => {
-          const exists = skills.some((m) => m.name === current.name);
-          if (!exists) {
-            skills.push(current);
-          }
-          return skills;
-        },
-        [],
+      return userSkills.concat(
+        getBuiltinSkillsForLang(getLang(), config.modelConfig),
       );
-
-      const buildinSkills = uniqueCurrentSkills.map(
-        (m) =>
-          ({
-            ...m,
-            modelConfig: {
-              ...config.modelConfig,
-              ...m.modelConfig,
-            },
-          }) as Skill,
-      );
-      return userSkills.concat(buildinSkills);
     },
     search(text: string) {
       return Object.values(get().skills);

--- a/app/utils/hooks.ts
+++ b/app/utils/hooks.ts
@@ -3,7 +3,7 @@ import { ModelCandidate } from "../client/api";
 import {
   useAccessStore,
   useAppConfig,
-  useMaskProviderModelsStore,
+  useSkillProviderModelsStore,
 } from "../store";
 import {
   collectModelsWithDefaultModel,
@@ -33,11 +33,13 @@ export function useAllModels() {
   ]);
 }
 
-export function useMaskProviderModels() {
-  const models = useMaskProviderModelsStore((state) => state.models);
+export function useSkillProviderModels() {
+  const models = useSkillProviderModelsStore((state) => state.models);
 
   return useMemo(() => normalizeModels(models), [models]);
 }
+
+export const useMaskProviderModels = useSkillProviderModels;
 
 export function useSessionModels(candidateModels?: readonly ModelCandidate[]) {
   const allModels = useAllModels();


### PR DESCRIPTION
## Summary
- unify session launch and skill naming across the new-chat, settings, and skill surfaces
- send the first prompt immediately when creating a new session from the launcher
- remove the default assistant greeting from empty authorized sessions

## Testing
- npx eslint app/components/chat.tsx app/components/new-chat.tsx app/constant.ts
- npx prettier --check app/components/chat.tsx app/components/new-chat.tsx app/constant.ts