### PR TITLE
Fallback MCP tool chats to chat completions

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -37,6 +37,7 @@ import {
   LLMUsage,
   MultimodalContent,
   normalizeModelEndpointPath,
+  normalizeSupportedEndpoints,
   SupportedEndpoint,
   SupportedTextEndpoint,
   SpeechOptions,
@@ -745,6 +746,31 @@ function extractResponsesStreamFallbackText(payload: any): string {
   return extractResponsesTextFromOutput(payload.output);
 }
 
+function shouldFallbackResponsesToolsToChatCompletions(config: {
+  useResponsesEndpoint: boolean;
+  useImageGenerationEndpoint: boolean;
+  providerName?: string;
+  supportedEndpoints?: readonly string[];
+  tools?: Array<{ function?: { name?: string } }>;
+}) {
+  if (!config.useResponsesEndpoint || config.useImageGenerationEndpoint) {
+    return false;
+  }
+  if (config.providerName !== ServiceProvider.OpenAI) {
+    return false;
+  }
+  const hasMcpTools = (config.tools ?? []).some((tool) =>
+    String(tool?.function?.name || "").startsWith("mcp__"),
+  );
+  if (!hasMcpTools) {
+    return false;
+  }
+  const supportedEndpoints = normalizeSupportedEndpoints(
+    config.supportedEndpoints,
+  );
+  return supportedEndpoints.includes(SupportedTextEndpoint.ChatCompletions);
+}
+
 export class ChatGPTApi implements LLMApi {
   private disableListModels = false;
 
@@ -910,12 +936,26 @@ export class ChatGPTApi implements LLMApi {
         funcs = toolPair[1] ?? {};
       }
 
-      const useResponsesEndpoint =
+      const preferResponsesEndpoint =
         !useImageGenerationEndpoint &&
         modelConfig.providerName !== ServiceProvider.Azure &&
         (endpointPath
           ? endpointPath === SupportedTextEndpoint.Responses
           : true);
+
+      const shouldFallbackToChatCompletions =
+        shouldFallbackResponsesToolsToChatCompletions({
+          useResponsesEndpoint: preferResponsesEndpoint,
+          useImageGenerationEndpoint,
+          providerName: modelConfig.providerName,
+          supportedEndpoints: options.config.supportedEndpoints,
+          tools,
+        });
+      const useResponsesEndpoint =
+        preferResponsesEndpoint && !shouldFallbackToChatCompletions;
+      const effectiveEndpointPath = shouldFallbackToChatCompletions
+        ? SupportedTextEndpoint.ChatCompletions
+        : endpointPath;
 
       let chatPath = "";
       if (modelConfig.providerName === ServiceProvider.Azure) {
@@ -944,8 +984,8 @@ export class ChatGPTApi implements LLMApi {
           ),
         );
       } else {
-        const textPath = endpointPath
-          ? endpointPath.replace(/^\//, "")
+        const textPath = effectiveEndpointPath
+          ? effectiveEndpointPath.replace(/^\//, "")
           : useResponsesEndpoint
             ? OpenaiPath.ResponsePath
             : OpenaiPath.ChatPath;
@@ -1055,6 +1095,7 @@ export class ChatGPTApi implements LLMApi {
         stream: shouldStream,
         responses: isResponsesPath(chatPath),
         tools: requestTools.length,
+        fallbackToChatCompletions: shouldFallbackToChatCompletions,
       });
 
       if (shouldStream) {


### PR DESCRIPTION
## Summary
- fallback OpenAI MCP tool chats to `/v1/chat/completions` when the model also supports it
- keep ordinary OpenAI chats on `/v1/responses`
- restore built-in reading/research skills that depend on Brave Search and Fetch

## Testing
- npx prettier --check app/client/platforms/openai.ts
- npx eslint app/client/platforms/openai.ts