### PR TITLE
Add MCP tool strategy for skills

### DIFF
--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -11,6 +11,9 @@ import {
   useAppConfig,
   useChatStore,
   ChatMessageTool,
+  allowSkillNativeMcpTools,
+  getSkillApiTools,
+  getSkillMcpTools,
 } from "@/app/store";
 import {
   getNativeToolBundle,
@@ -553,15 +556,18 @@ export class ClaudeApi implements LLMApi {
 
     if (shouldStream) {
       let index = -1;
-      const [tools, funcs] = await getNativeToolBundle(
-        useChatStore.getState().currentSession().mask?.plugin || [],
-        {
-          includeMcp: shouldUseNativeMcpTools({
+      const sessionSkill = useChatStore.getState().currentSession().mask;
+      const skillApiTools = getSkillApiTools(sessionSkill);
+      const skillMcpTools = getSkillMcpTools(sessionSkill);
+      const [tools, funcs] = await getNativeToolBundle(skillApiTools, {
+        includeMcp:
+          allowSkillNativeMcpTools(sessionSkill) &&
+          shouldUseNativeMcpTools({
             providerName: options.config.providerName,
             endpointPath: chatEndpointPath,
           }),
-        },
-      );
+        mcpClientIds: skillMcpTools,
+      });
       return stream(
         path,
         requestBody,

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -11,6 +11,7 @@ import {
 } from "@/app/constant";
 import {
   ChatMessageTool,
+  allowSkillNativeMcpTools,
   getSkillApiTools,
   getSkillBuiltInTools,
   getSkillMcpTools,
@@ -951,10 +952,11 @@ export class ChatGPTApi implements LLMApi {
       const skillApiTools = getSkillApiTools(sessionSkill);
       const skillMcpTools = getSkillMcpTools(sessionSkill);
       const skillBuiltInTools = getSkillBuiltInTools(sessionSkill);
+      const allowNativeMcpTools = allowSkillNativeMcpTools(sessionSkill);
       if (shouldStream) {
         const toolPair = (await getNativeToolBundle(skillApiTools, {
           includeMcp:
-            skillMcpTools.length > 0 &&
+            allowNativeMcpTools &&
             shouldUseNativeMcpTools({
               providerName: modelConfig.providerName,
               endpointPath,

--- a/app/components/auth.tsx
+++ b/app/components/auth.tsx
@@ -145,7 +145,7 @@ export function AuthPage() {
         persistWalletHistory(history);
       }
       setWalletHistory(history);
-      setSelectedWalletAccount(account || "");
+      setSelectedWalletAccount(account || history[0] || "");
       if (valid) {
         setUcanStatus("authorized");
       } else if (account) {

--- a/app/components/discovery.tsx
+++ b/app/components/discovery.tsx
@@ -34,6 +34,7 @@ import { IconButton } from "./button";
 import { ErrorBoundary } from "./error";
 import BrainIcon from "../icons/brain.svg";
 import CloseIcon from "../icons/close.svg";
+import EditIcon from "../icons/edit.svg";
 import EyeIcon from "../icons/eye.svg";
 import ModelServiceIcon from "../icons/llm-icons/default.svg";
 import ToolIcon from "../icons/tool.svg";
@@ -90,6 +91,14 @@ function getDiscoveryPath(view: DiscoveryView, type: CapabilityType) {
   if (type !== "all") params.set("type", type);
   const query = params.toString();
   return query ? `${Path.Discovery}?${query}` : Path.Discovery;
+}
+
+function getSkillConfigPath(skill: Skill) {
+  return `${Path.Skills}?skill=${encodeURIComponent(String(skill.id))}`;
+}
+
+function getBuiltinSkillPackageId(skill: Skill) {
+  return `builtin.${skill.lang}.${skill.createdAt}`;
 }
 
 function getCapabilityIcon(type: Capability["type"]) {
@@ -535,7 +544,7 @@ export function DiscoveryPage() {
 
     if (item.type === "skill" && item.skill) {
       if (item.runtimeStatus !== "ready") {
-        navigate(Path.Skills);
+        openSkillConfig(item.skill);
         return;
       }
       if (chatStore.newSession(item.skill) !== false) {
@@ -544,6 +553,31 @@ export function DiscoveryPage() {
       return;
     }
     navigate(item.path);
+  };
+
+  const openSkillConfig = (skill: Skill) => {
+    if (!skill.builtin) {
+      navigate(getSkillConfigPath(skill));
+      return;
+    }
+
+    const packageId = getBuiltinSkillPackageId(skill);
+    const existingSkill = Object.values(useSkillStore.getState().skills).find(
+      (item) =>
+        item.packageId === packageId ||
+        (!item.builtin &&
+          item.lang === skill.lang &&
+          item.createdAt === skill.createdAt &&
+          item.name === skill.name),
+    );
+    const configurableSkill =
+      existingSkill ??
+      useSkillStore.getState().create({
+        ...skill,
+        packageId,
+      });
+
+    navigate(getSkillConfigPath(configurableSkill));
   };
 
   const getActionText = (item: Capability) => {
@@ -665,6 +699,14 @@ export function DiscoveryPage() {
                     bordered
                     onClick={() => handleCapabilityAction(item)}
                   />
+                  {item.type === "skill" && item.skill && (
+                    <IconButton
+                      icon={<EditIcon />}
+                      text={Locale.Discovery.Configure}
+                      bordered
+                      onClick={() => openSkillConfig(item.skill!)}
+                    />
+                  )}
                 </div>
               </div>
             ))}

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -16,6 +16,7 @@ import DragIcon from "../icons/drag.svg";
 import {
   DEFAULT_SKILL_AVATAR,
   Skill,
+  allowSkillNativeMcpTools,
   getSkillBuiltInTools,
   getSkillMcpTools,
   getLaunchableSkills,
@@ -320,6 +321,7 @@ export function SkillConfig(props: {
   const skillProviderModels = useMaskProviderModels();
   const selectedBuiltInTools = getSkillBuiltInTools(skill);
   const selectedMcpTools = getSkillMcpTools(skill);
+  const allowNativeMcpTools = allowSkillNativeMcpTools(skill);
   const selectedCandidateModels = useMemo(
     () => normalizeModelCandidates(skill.candidateModels),
     [skill.candidateModels],
@@ -529,6 +531,24 @@ export function SkillConfig(props: {
             readOnly
             value={mcpToolSummary}
             onClick={() => setShowMcpToolSelector(true)}
+          ></input>
+        </ListItem>
+        <ListItem
+          title={Locale.Mask.Config.Tools.NativeMcp.Title}
+          subTitle={Locale.Mask.Config.Tools.NativeMcp.SubTitle}
+        >
+          <input
+            aria-label={Locale.Mask.Config.Tools.NativeMcp.Title}
+            type="checkbox"
+            checked={allowNativeMcpTools}
+            onChange={(e) => {
+              props.updateMask((mask) => {
+                mask.toolStrategy = {
+                  ...mask.toolStrategy,
+                  nativeMcpTools: e.currentTarget.checked ? "auto" : "off",
+                };
+              });
+            }}
           ></input>
         </ListItem>
         <ListItem

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -44,7 +44,7 @@ import {
 } from "./ui-lib";
 import { Avatar, AvatarPicker } from "./emoji";
 import Locale, { AllLangs, ALL_LANG_OPTIONS, Lang } from "../locales";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import chatStyle from "./chat.module.scss";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
@@ -902,6 +902,7 @@ export function ContextPrompts(props: {
 
 export function SkillPage() {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const skillStore = useSkillStore();
   const chatStore = useChatStore();
@@ -947,7 +948,23 @@ export function SkillPage() {
   const [editingSkillId, setEditingSkillId] = useState<string | undefined>();
   const editingSkill =
     skillStore.get(editingSkillId) ?? BUILTIN_SKILL_STORE.get(editingSkillId);
-  const closeSkillModal = () => setEditingSkillId(undefined);
+  const closeSkillModal = () => {
+    setEditingSkillId(undefined);
+    if (new URLSearchParams(location.search).has("skill")) {
+      navigate(Path.Skills, { replace: true });
+    }
+  };
+
+  useEffect(() => {
+    const skillId = new URLSearchParams(location.search).get("skill");
+    if (!skillId) return;
+    const matchedSkill = allSkills.find(
+      (skill) => String(skill.id) === skillId,
+    );
+    if (matchedSkill) {
+      setEditingSkillId(String(matchedSkill.id));
+    }
+  }, [allSkills, location.search]);
 
   const downloadAll = () => {
     downloadAs(

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -850,7 +850,11 @@ const cn = {
         },
         Mcp: {
           Title: "MCP",
-          SubTitle: "选择这个技能可以调用的 MCP 服务",
+          SubTitle: "限制这个技能可调用的 MCP 服务；未选择表示不限制",
+        },
+        NativeMcp: {
+          Title: "允许 MCP 工具",
+          SubTitle: "开启后，支持工具调用的模型可主动调用已连接的 MCP 服务",
         },
       },
       Sync: {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -723,6 +723,7 @@ const cn = {
     },
     SourceLabel: "来源",
     Manage: "管理",
+    Configure: "配置",
     Enable: "启用",
     Install: "安装",
     Use: "开始使用",
@@ -853,8 +854,9 @@ const cn = {
           SubTitle: "限制这个技能可调用的 MCP 服务；未选择表示不限制",
         },
         NativeMcp: {
-          Title: "允许 MCP 工具",
-          SubTitle: "开启后，支持工具调用的模型可主动调用已连接的 MCP 服务",
+          Title: "MCP 工具策略",
+          SubTitle:
+            "用于深度思考等技能；开启后模型可调用 Brave/fetch 等已连接 MCP，关闭后仅使用模型自身能力",
         },
       },
       Sync: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -865,7 +865,13 @@ const en: LocaleType = {
         },
         Mcp: {
           Title: "MCP",
-          SubTitle: "MCP services this skill can call",
+          SubTitle:
+            "Restrict which MCP services this skill can call; none selected means unrestricted",
+        },
+        NativeMcp: {
+          Title: "Allow MCP Tools",
+          SubTitle:
+            "When enabled, tool-capable models may call connected MCP services",
         },
       },
       Sync: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -733,6 +733,7 @@ const en: LocaleType = {
     },
     SourceLabel: "Source",
     Manage: "Manage",
+    Configure: "Configure",
     Enable: "Enable",
     Install: "Install",
     Use: "Start",
@@ -869,9 +870,9 @@ const en: LocaleType = {
             "Restrict which MCP services this skill can call; none selected means unrestricted",
         },
         NativeMcp: {
-          Title: "Allow MCP Tools",
+          Title: "MCP Tool Strategy",
           SubTitle:
-            "When enabled, tool-capable models may call connected MCP services",
+            "Used by skills such as Deep Reasoning; enabled allows Brave/fetch and other connected MCP tools, disabled uses only the model itself",
         },
       },
       Sync: {

--- a/app/skills/cn.ts
+++ b/app/skills/cn.ts
@@ -125,6 +125,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     createdAt: 1700000001006,
     syncGlobalConfig: false,
     candidateModels: [{ capability: "reasoning" }],
+    toolStrategy: {
+      nativeMcpTools: "auto",
+    },
     context: [
       {
         id: "cn-deep-reasoning-0",

--- a/app/skills/en.ts
+++ b/app/skills/en.ts
@@ -129,6 +129,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     createdAt: 1700000002006,
     syncGlobalConfig: false,
     candidateModels: [{ capability: "reasoning" }],
+    toolStrategy: {
+      nativeMcpTools: "auto",
+    },
     context: [
       {
         id: "en-deep-reasoning-0",

--- a/app/skills/utils.ts
+++ b/app/skills/utils.ts
@@ -14,6 +14,7 @@ type BuiltinSkillInput = {
   context: ChatMessage[];
   syncGlobalConfig?: boolean;
   candidateModels?: BuiltinSkill["candidateModels"];
+  toolStrategy?: BuiltinSkill["toolStrategy"];
   launch?: BuiltinSkill["launch"];
   modelConfig?: Partial<ModelConfig>;
 };

--- a/app/store/skill.ts
+++ b/app/store/skill.ts
@@ -15,6 +15,12 @@ export type SkillToolsConfig = {
   apiTools?: string[];
 };
 
+export type SkillNativeMcpToolsMode = "auto" | "off";
+
+export type SkillToolStrategy = {
+  nativeMcpTools?: SkillNativeMcpToolsMode;
+};
+
 export type Skill = {
   id: string;
   packageId?: string;
@@ -33,6 +39,7 @@ export type Skill = {
   builtin: boolean;
   plugin?: string[];
   tools?: SkillToolsConfig;
+  toolStrategy?: SkillToolStrategy;
   enableArtifacts?: boolean;
   enableCodeFold?: boolean;
   launch?: {
@@ -70,6 +77,9 @@ export const createEmptySkill = () =>
       builtInTools: [],
       mcpTools: [],
       apiTools: [],
+    },
+    toolStrategy: {
+      nativeMcpTools: "auto",
     },
   }) as Skill;
 
@@ -125,6 +135,14 @@ export function getSkillApiTools(skill: Skill) {
   return skill.tools?.apiTools ?? skill.plugin ?? [];
 }
 
+export function getSkillNativeMcpToolsMode(skill: Skill) {
+  return skill.toolStrategy?.nativeMcpTools ?? "auto";
+}
+
+export function allowSkillNativeMcpTools(skill: Skill) {
+  return getSkillNativeMcpToolsMode(skill) !== "off";
+}
+
 export function syncSkillLegacyPlugin(skill: Skill) {
   const apiTools = skill.tools?.apiTools ?? skill.plugin ?? [];
   skill.plugin = apiTools;
@@ -132,6 +150,9 @@ export function syncSkillLegacyPlugin(skill: Skill) {
     builtInTools: skill.tools?.builtInTools ?? [],
     mcpTools: skill.tools?.mcpTools ?? [],
     apiTools,
+  };
+  skill.toolStrategy = {
+    nativeMcpTools: skill.toolStrategy?.nativeMcpTools ?? "auto",
   };
 }
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,7 +11,11 @@ const config = {
   testEnvironment: "jsdom" as const,
   testMatch: ["**/*.test.js", "**/*.test.ts", "**/*.test.jsx", "**/*.test.tsx"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  modulePathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/out/"],
+  modulePathIgnorePatterns: [
+    "<rootDir>/.next/",
+    "<rootDir>/out/",
+    "<rootDir>/output/",
+  ],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
     "^@yeying-community/web3-bs$":

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "jest-environment-jsdom": "^30.4.1",
         "lint-staged": "^17.0.7",
         "prettier": "^3.8.4",
+        "ts-node": "^10.9.2",
         "tsx": "^4.22.4",
         "typescript": "6.0.3",
         "watch": "^1.0.2",
@@ -1693,6 +1694,30 @@
       "resolved": "https://registry.npmmirror.com/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmmirror.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -4767,6 +4792,34 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmmirror.com/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmmirror.com/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5123,6 +5176,7 @@
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.8.0.tgz",
       "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6595,6 +6649,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmmirror.com/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
@@ -6696,6 +6763,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmmirror.com/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7679,6 +7753,13 @@
         }
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "dev": true,
@@ -8527,6 +8608,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -12445,6 +12536,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmmirror.com/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -21375,6 +21473,51 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmmirror.com/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "dev": true,
@@ -21940,6 +22083,13 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -22535,6 +22685,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "jest-environment-jsdom": "^30.4.1",
     "lint-staged": "^17.0.7",
     "prettier": "^3.8.4",
+    "ts-node": "^10.9.2",
     "tsx": "^4.22.4",
     "typescript": "6.0.3",
     "watch": "^1.0.2",

--- a/public/skills.json
+++ b/public/skills.json
@@ -150,6 +150,9 @@
                     "capability": "reasoning"
                 }
             ],
+            "toolStrategy": {
+                "nativeMcpTools": "auto"
+            },
             "context": [
                 {
                     "id": "cn-deep-reasoning-0",
@@ -365,6 +368,9 @@
                     "capability": "reasoning"
                 }
             ],
+            "toolStrategy": {
+                "nativeMcpTools": "auto"
+            },
             "context": [
                 {
                     "id": "en-deep-reasoning-0",


### PR DESCRIPTION
## Summary
- add a skill-level MCP/native tool strategy with auto/off modes
- default Deep Reasoning to allow MCP tools while letting users disable them from skill settings
- apply the strategy in OpenAI-compatible and Anthropic request paths

## Validation
- npx tsc --noEmit
- npm run test:ci -- test/reasoning-request.test.ts test/reasoning-model-filter.test.ts test/anthropic-tool-round.test.ts test/text-endpoint-selection.test.ts
- npx eslint app/store/skill.ts app/skills/utils.ts app/skills/cn.ts app/skills/en.ts app/components/mask.tsx app/locales/cn.ts app/locales/en.ts app/client/platforms/openai.ts app/client/platforms/anthropic.ts
- npm run build