### PR TITLE
Improve marketplace skill runtime flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Chat（UCAN 定制版）
 - 用户登录方案：`docs/用户登录方案.md`
 - 数据同步：`docs/数据同步方案.md`
 - 技能发布、上线、配置与使用流程：`docs/技能发布上线配置使用流程.md`
+- 市场后端与技能运行配置方案：`docs/市场后端与技能运行配置方案.md`
 - Cloudflare Pages 部署指南：`docs/CloudflarePages部署指南.md`
 - Vercel 使用说明：`docs/Vercel使用说明.md`
 - 文生图与上传图片聊天工作流实现说明：`docs/文生图与上传图片聊天工作流实现说明.md`

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -145,6 +145,10 @@ import {
   normalizeModelCandidates,
   normalizeProviderName,
 } from "../utils/model";
+import {
+  disablePlainChatReasoning,
+  isPlainChatSkill,
+} from "../utils/plain-chat";
 import { RealtimeChat } from "@/app/components/realtime-chat";
 import clsx from "clsx";
 import { getAvailableClientsCount, isMcpEnabled } from "../mcp/actions";
@@ -1306,7 +1310,9 @@ function ChatView() {
       // auto sync mask config from global config
       const shouldSyncFromGlobal = sessionSkill.syncGlobalConfig !== false;
       if (shouldSyncFromGlobal) {
-        sessionSkill.modelConfig = { ...config.modelConfig };
+        sessionSkill.modelConfig = isPlainChatSkill(sessionSkill)
+          ? disablePlainChatReasoning(config.modelConfig)
+          : { ...config.modelConfig };
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/components/discovery.tsx
+++ b/app/components/discovery.tsx
@@ -388,7 +388,7 @@ export function DiscoveryPage() {
     );
     const mcpToolItems: Capability[] = mcpPresetServers.map((server) => {
       const serverConfig = mcpConfig?.mcpServers[server.id];
-      const serverStatus = mcpStatuses[server.id]?.status;
+      const serverStatus = mcpStatuses?.[server.id]?.status;
       const installed = Boolean(serverConfig);
       const status =
         serverStatus === "active"

--- a/app/components/discovery.tsx
+++ b/app/components/discovery.tsx
@@ -43,7 +43,9 @@ import { useAccessStore } from "../store/access";
 import {
   getSkillRuntimeIssueSummary,
   getSkillRuntimeStatusOrder,
+  hasSkillMcpRuntimeIssue,
   resolveSkillRuntimeStatus,
+  SkillRuntimeResult,
   SkillRuntimeStatus,
 } from "../skills/runtime";
 
@@ -69,6 +71,7 @@ type Capability = {
   skillPackage?: SkillPackage;
   skillPackageLang?: Lang;
   runtimeStatus?: SkillRuntimeStatus;
+  runtimeResult?: SkillRuntimeResult;
 };
 
 const typeOrder: CapabilityType[] = ["all", "skill", "mcp", "provider"];
@@ -125,8 +128,8 @@ export function DiscoveryPage() {
   const defaultModel = useAccessStore((state) => state.defaultModel);
   const [mcpConfig, setMcpConfig] = useState<McpConfigData>();
   const [mcpStatuses, setMcpStatuses] = useState<
-    Record<string, ServerStatusResponse>
-  >({});
+    Record<string, ServerStatusResponse> | undefined
+  >();
   const [communitySkillPackages, setCommunitySkillPackages] =
     useState<SkillPackageList>({});
   const [communityMcpServers, setCommunityMcpServers] = useState<
@@ -261,6 +264,7 @@ export function DiscoveryPage() {
           globalModelConfig: modelConfig,
           installedPluginIds,
           installedMcpServerIds,
+          mcpStatuses,
         });
         const runtimeSummary = getSkillRuntimeIssueSummary(runtime);
         return {
@@ -293,6 +297,7 @@ export function DiscoveryPage() {
           installed: !skill.builtin,
           skill: runtimeSkill,
           runtimeStatus: runtime.status,
+          runtimeResult: runtime,
         };
       })
       .sort((a, b) => {
@@ -326,6 +331,7 @@ export function DiscoveryPage() {
           globalModelConfig: modelConfig,
           installedPluginIds,
           installedMcpServerIds,
+          mcpStatuses,
         });
         const runtimeSummary = getSkillRuntimeIssueSummary(runtime);
 
@@ -366,6 +372,7 @@ export function DiscoveryPage() {
           skillPackage,
           skillPackageLang: currentLang,
           runtimeStatus: runtime.status,
+          runtimeResult: runtime,
         };
       })
       .sort((a, b) => {
@@ -536,14 +543,20 @@ export function DiscoveryPage() {
         if (chatStore.newSession(installedSkill) !== false) {
           navigate(Path.Chat);
         }
+      } else if (hasSkillMcpRuntimeIssue(item.runtimeResult)) {
+        navigate(Path.McpMarket);
       } else {
-        navigate(Path.Skills);
+        openSkillConfig(installedSkill);
       }
       return;
     }
 
     if (item.type === "skill" && item.skill) {
       if (item.runtimeStatus !== "ready") {
+        if (hasSkillMcpRuntimeIssue(item.runtimeResult)) {
+          navigate(Path.McpMarket);
+          return;
+        }
         openSkillConfig(item.skill);
         return;
       }

--- a/app/components/new-chat.module.scss
+++ b/app/components/new-chat.module.scss
@@ -186,6 +186,33 @@
     flex-shrink: 0;
   }
 
+  .empty-skills {
+    grid-column: 1 / -1;
+    min-height: 58px;
+    padding: 0 14px;
+    border: var(--border-in-light);
+    border-radius: 12px;
+    color: var(--black);
+    background: var(--white);
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    opacity: 0.82;
+
+    button {
+      flex-shrink: 0;
+      border: 0;
+      padding: 6px 10px;
+      border-radius: 999px;
+      color: var(--primary);
+      background: var(--hover-color);
+      cursor: pointer;
+      font-weight: 600;
+    }
+  }
+
   .recent-skills {
     width: min(1100px, calc(100% - 40px));
     min-width: 0;

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -25,12 +25,13 @@ import { ServiceProvider } from "../constant";
 import { useAccessStore } from "../store/access";
 import {
   getSkillRuntimeStatusOrder,
+  hasSkillMcpRuntimeIssue,
   resolveSkillRuntimeStatus,
   SkillRuntimeResult,
 } from "../skills/runtime";
 import { usePluginStore } from "../store/plugin";
-import { getMcpConfigFromFile } from "../mcp/actions";
-import { McpConfigData } from "../mcp/types";
+import { getClientsStatus, getMcpConfigFromFile } from "../mcp/actions";
+import { McpConfigData, ServerStatusResponse } from "../mcp/types";
 
 function SkillItem(props: {
   skill: Skill;
@@ -97,6 +98,9 @@ export function NewChat() {
   const [draft, setDraft] = useState("");
   const [selectedModelValue, setSelectedModelValue] = useState("");
   const [mcpConfig, setMcpConfig] = useState<McpConfigData>();
+  const [mcpStatuses, setMcpStatuses] = useState<
+    Record<string, ServerStatusResponse> | undefined
+  >();
   const [hiddenOrphanSkillKeys, setHiddenOrphanSkillKeys] = useState(() => {
     const raw = localStorage.getItem(HIDDEN_ORPHAN_SKILL_KEYS);
     if (!raw) return [] as string[];
@@ -145,10 +149,11 @@ export function NewChat() {
 
   useEffect(() => {
     let cancelled = false;
-    getMcpConfigFromFile()
-      .then((config) => {
+    Promise.all([getMcpConfigFromFile(), getClientsStatus()])
+      .then(([config, statuses]) => {
         if (!cancelled) {
           setMcpConfig(config);
+          setMcpStatuses(statuses);
         }
       })
       .catch((error) => {
@@ -173,6 +178,7 @@ export function NewChat() {
           globalModelConfig: config.modelConfig,
           installedPluginIds,
           installedMcpServerIds,
+          mcpStatuses,
         }),
       ]),
     );
@@ -184,6 +190,7 @@ export function NewChat() {
     config.models,
     installedMcpServerIds,
     installedPluginIds,
+    mcpStatuses,
     recentSkills,
     skills,
   ]);
@@ -223,6 +230,7 @@ export function NewChat() {
             globalModelConfig: config.modelConfig,
             installedPluginIds,
             installedMcpServerIds,
+            mcpStatuses,
           });
         const statusLabel =
           runtime.status === "ready"
@@ -246,6 +254,7 @@ export function NewChat() {
       entrySkills,
       installedMcpServerIds,
       installedPluginIds,
+      mcpStatuses,
       skillRuntimeMap,
     ],
   );
@@ -349,7 +358,7 @@ export function NewChat() {
     if (!skill) return;
     const runtime = skillRuntimeMap.get(getSkillEntryKey(skill));
     if (runtime && runtime.status !== "ready") {
-      navigate(Path.Skills);
+      navigate(hasSkillMcpRuntimeIssue(runtime) ? Path.McpMarket : Path.Skills);
       return;
     }
 

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -36,7 +36,7 @@ import { McpConfigData, ServerStatusResponse } from "../mcp/types";
 function SkillItem(props: {
   skill: Skill;
   runtime: SkillRuntimeResult;
-  statusLabel: string;
+  statusLabel?: string;
   onClick?: () => void;
   onDelete?: () => void;
   deletable?: boolean;
@@ -62,7 +62,9 @@ function SkillItem(props: {
         <div className={clsx(styles["mask-name"], "one-line")}>
           {props.skill.name}
         </div>
-        <div className={styles["mask-status"]}>{props.statusLabel}</div>
+        {props.statusLabel && (
+          <div className={styles["mask-status"]}>{props.statusLabel}</div>
+        )}
       </div>
       {props.deletable && props.onDelete && (
         <button
@@ -234,7 +236,7 @@ export function NewChat() {
           });
         const statusLabel =
           runtime.status === "ready"
-            ? Locale.Discovery.Status.Enabled
+            ? undefined
             : runtime.status === "needs_config"
               ? Locale.Discovery.Status.Configurable
               : Locale.Discovery.Status.Unavailable;
@@ -467,13 +469,24 @@ export function NewChat() {
         </div>
         <IconButton
           text={Locale.NewChat.More}
-          onClick={() => navigate(Path.Skills)}
+          onClick={() => navigate(`${Path.Discovery}?type=skill`)}
           icon={<EyeIcon />}
           bordered
         />
       </div>
 
       <div className={styles["featured-masks"]}>
+        {entrySkillItems.length === 0 && (
+          <div className={styles["empty-skills"]}>
+            <span>{Locale.NewChat.EmptySkills}</span>
+            <button
+              type="button"
+              onClick={() => navigate(`${Path.Discovery}?type=skill`)}
+            >
+              {Locale.NewChat.ExploreSkills}
+            </button>
+          </div>
+        )}
         {entrySkillItems.map(({ skill, runtime, statusLabel }) => (
           <SkillItem
             key={skill.id}

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -26,7 +26,7 @@ const cn = {
     Confirm: "确认",
     Later: "稍后再说",
     TopTips:
-      "🥳 Chat AI 首发，立刻解锁 qwen3.7-max，deepseek-v4-pro，gpt-5.5，claude-4.7等最新大模型",
+      "🥳 Chat AI 首发，立刻解锁 qwen3.7-max、deepseek-v4-pro、gpt-5.5、claude-4.8等最新大模型",
   },
   ChatItem: {
     ChatItemCount: (count: number) => `${count} 条对话`,

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -898,6 +898,8 @@ const cn = {
     FeaturedTitle: "技能",
     FeaturedSubTitle: "技能会带上适合当前任务的提示词和模型参数。",
     More: "全部",
+    EmptySkills: "暂无可用技能",
+    ExploreSkills: "去发现",
   },
 
   URLCommand: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -913,6 +913,8 @@ const en: LocaleType = {
     FeaturedTitle: "Skills",
     FeaturedSubTitle: "Skills apply task-specific prompts and model settings.",
     More: "All",
+    EmptySkills: "No available skills",
+    ExploreSkills: "Discover",
     NotShow: "Never Show Again",
     ConfirmNoShow: "Confirm to disable？You can enable it in settings later.",
   },

--- a/app/mcp/preset-servers.ts
+++ b/app/mcp/preset-servers.ts
@@ -38,8 +38,8 @@ export const OFFICIAL_MCP_PRESET_SERVERS: PresetServer[] = [
     description: "Official MCP server for fetching and converting web content.",
     repo: `${OFFICIAL_REPO_BASE}/fetch`,
     tags: ["official", "web", "http"],
-    command: "uvx",
-    baseArgs: ["mcp-server-fetch"],
+    command: "mcp-server-fetch",
+    baseArgs: [],
     configurable: false,
   },
   {

--- a/app/skills/runtime.ts
+++ b/app/skills/runtime.ts
@@ -1,6 +1,7 @@
 import { LLMModel } from "../client/api";
-import { Skill, getSkillApiTools, getSkillMcpTools } from "../store/skill";
 import { ModelConfig } from "../store/config";
+import { ServerStatusResponse } from "../mcp/types";
+import type { Skill } from "../store/skill";
 import {
   collectModelsWithDefaultModel,
   filterModelsByCandidates,
@@ -10,7 +11,11 @@ import {
 
 export type SkillRuntimeStatus = "ready" | "needs_config" | "unavailable";
 
-export type SkillRuntimeIssueType = "model" | "tool";
+export type SkillRuntimeIssueType =
+  | "model"
+  | "api_tool"
+  | "mcp_missing"
+  | "mcp_inactive";
 
 export type SkillRuntimeIssue = {
   type: SkillRuntimeIssueType;
@@ -39,6 +44,22 @@ export function getSkillRuntimeIssueSummary(result: SkillRuntimeResult) {
   return result.issues.map((issue) => issue.message).join(" · ");
 }
 
+export function hasSkillMcpRuntimeIssue(result?: SkillRuntimeResult) {
+  return (
+    result?.issues.some(
+      (issue) => issue.type === "mcp_missing" || issue.type === "mcp_inactive",
+    ) ?? false
+  );
+}
+
+function getSkillApiTools(skill: Skill) {
+  return skill.tools?.apiTools ?? skill.plugin ?? [];
+}
+
+function getSkillMcpTools(skill: Skill) {
+  return skill.tools?.mcpTools ?? [];
+}
+
 export function resolveSkillRuntimeStatus(params: {
   skill: Skill;
   models: readonly LLMModel[];
@@ -48,6 +69,7 @@ export function resolveSkillRuntimeStatus(params: {
   globalModelConfig: ModelConfig;
   installedPluginIds?: readonly string[];
   installedMcpServerIds?: readonly string[];
+  mcpStatuses?: Record<string, ServerStatusResponse | undefined>;
 }): SkillRuntimeResult {
   const {
     skill,
@@ -58,6 +80,7 @@ export function resolveSkillRuntimeStatus(params: {
     globalModelConfig,
     installedPluginIds,
     installedMcpServerIds,
+    mcpStatuses,
   } = params;
 
   const runtimeModels = collectModelsWithDefaultModel(
@@ -89,9 +112,15 @@ export function resolveSkillRuntimeStatus(params: {
     (id) => !pluginIdSet.has(id),
   ).length;
   const mcpServerIdSet = new Set(installedMcpServerIds ?? []);
-  const missingMcpServerCount = getSkillMcpTools(skill).filter(
+  const mcpTools = getSkillMcpTools(skill);
+  const missingMcpServerCount = mcpTools.filter(
     (id) => !mcpServerIdSet.has(id),
   ).length;
+  const inactiveMcpServerCount = mcpTools.filter((id) => {
+    if (!mcpServerIdSet.has(id)) return false;
+    if (!mcpStatuses) return false;
+    return mcpStatuses[id]?.status !== "active";
+  }).length;
 
   const issues: SkillRuntimeIssue[] = [];
 
@@ -126,7 +155,7 @@ export function resolveSkillRuntimeStatus(params: {
 
   if (missingPluginCount > 0) {
     issues.push({
-      type: "tool",
+      type: "api_tool",
       message:
         missingPluginCount === 1
           ? "缺少 1 个工具配置"
@@ -136,11 +165,21 @@ export function resolveSkillRuntimeStatus(params: {
 
   if (missingMcpServerCount > 0) {
     issues.push({
-      type: "tool",
+      type: "mcp_missing",
       message:
         missingMcpServerCount === 1
           ? "缺少 1 个 MCP 配置"
           : `缺少 ${missingMcpServerCount} 个 MCP 配置`,
+    });
+  }
+
+  if (inactiveMcpServerCount > 0) {
+    issues.push({
+      type: "mcp_inactive",
+      message:
+        inactiveMcpServerCount === 1
+          ? "1 个 MCP 未正常运行"
+          : `${inactiveMcpServerCount} 个 MCP 未正常运行`,
     });
   }
 

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -53,6 +53,10 @@ import { executeMcpAction, getAllTools, isMcpEnabled } from "../mcp/actions";
 import { extractMcpJson, isMcpJson } from "../mcp/utils";
 import { isValidUcanAuthorization } from "../plugins/wallet";
 import { shouldUseNativeMcpTools } from "./native-tools";
+import {
+  disablePlainChatReasoning,
+  isPlainChatSkill,
+} from "../utils/plain-chat";
 
 const localStorage = safeLocalStorage();
 
@@ -637,7 +641,17 @@ export const useChatStore = createPersistStore(
           return;
         }
         const session = get().currentSession();
-        const modelConfig = session.mask.modelConfig;
+        const modelConfig = isPlainChatSkill(session.mask)
+          ? disablePlainChatReasoning(session.mask.modelConfig)
+          : session.mask.modelConfig;
+        if (
+          isPlainChatSkill(session.mask) &&
+          session.mask.modelConfig.reasoningMode !== modelConfig.reasoningMode
+        ) {
+          get().updateTargetSession(session, (session) => {
+            session.mask.modelConfig = modelConfig;
+          });
+        }
         const normalizedAttachments = attachments ?? [];
         const hasDocumentAttachment = hasNonImageDocumentAttachment(
           normalizedAttachments,

--- a/app/store/skill.ts
+++ b/app/store/skill.ts
@@ -6,6 +6,7 @@ import { ModelConfig, useAppConfig } from "./config";
 import { StoreKey } from "../constant";
 import { nanoid } from "nanoid";
 import { createPersistStore } from "../utils/store";
+import { disablePlainChatReasoning } from "../utils/plain-chat";
 
 export type BuiltInSkillToolType = "web_search";
 
@@ -67,7 +68,7 @@ export const createEmptySkill = () =>
     name: DEFAULT_TOPIC,
     context: [],
     syncGlobalConfig: true, // use global config as default
-    modelConfig: { ...useAppConfig.getState().modelConfig },
+    modelConfig: disablePlainChatReasoning(useAppConfig.getState().modelConfig),
     candidateModels: [],
     lang: getLang(),
     builtin: false,

--- a/app/utils/plain-chat.ts
+++ b/app/utils/plain-chat.ts
@@ -1,0 +1,25 @@
+import type { ModelConfig } from "../store/config";
+import type { Skill } from "../store/skill";
+
+export function disablePlainChatReasoning(modelConfig: ModelConfig) {
+  return {
+    ...modelConfig,
+    reasoningMode: "off" as const,
+    reasoningEffort: modelConfig.reasoningEffort ?? "medium",
+  };
+}
+
+export function isPlainChatSkill(skill: Skill) {
+  return (
+    !skill.builtin &&
+    !skill.description &&
+    !skill.category &&
+    !skill.starters?.length &&
+    !skill.context?.length &&
+    !skill.plugin?.length &&
+    !skill.tools?.builtInTools?.length &&
+    !skill.tools?.mcpTools?.length &&
+    !skill.tools?.apiTools?.length &&
+    !skill.launch
+  );
+}

--- a/docs/市场后端与技能运行配置方案.md
+++ b/docs/市场后端与技能运行配置方案.md
@@ -1,0 +1,626 @@
+# 市场后端与技能运行配置方案
+
+## 1. 背景
+
+当前 Chat 已经具备基础市场能力：
+
+- 从社区市场仓库加载技能包和 MCP 包。
+- 在发现页展示技能、MCP 和模型服务商。
+- 用户可以安装技能，进入技能会话或工作区。
+- 技能可以声明模型、工具、MCP 和权限。
+- 本地可以保存技能配置和 MCP 配置。
+
+这个模式适合 MVP，但继续扩展付费技能、第三方发布、组织可见范围、私有 MCP、模型服务商配置时，纯前端加静态 JSON 会变得不可控。
+
+核心问题：
+
+- 前端不能可靠判断用户是否已购买、是否有组织授权。
+- 前端不应保存和分发第三方密钥、私有 endpoint、本地路径等敏感配置。
+- 静态 JSON 无法承载审核、下架、版本灰度、统计、投诉和风控。
+- 用户点击技能后，如果缺模型、缺 MCP、缺授权，当前流程容易跳转分散，用户不知道下一步做什么。
+
+结论：发现市场需要从“静态列表”演进为“市场发现 + 安装授权 + 运行配置”的完整闭环。
+
+## 2. 产品目标
+
+用户视角只需要理解三件事：
+
+- 我想完成什么任务。
+- 这个技能现在能不能用。
+- 如果不能用，下一步补什么配置。
+
+产品目标：
+
+- 用户从发现页点击技能后，系统自动判断可用性。
+- 可用时直接进入会话或工作区。
+- 不可用时进入清晰的配置向导，而不是让用户自己找设置项。
+- 付费、试用、组织授权、第三方发布都能在同一套状态模型下表达。
+- Chat 前端仍然可以离线或本地使用基础能力，但正式市场能力由后端托管。
+
+## 3. 当前阶段过渡架构
+
+现阶段不急于一次性引入完整后端。为了确保产品持续可用，可以采用渐进式方案：
+
+- 静态市场数据继续通过 GitHub 仓库管理。
+- 模型供应商以 Router 为主入口，第三方 Provider 作为补充。
+- MCP 同时支持本地服务和第三方服务，通过 GitHub 配置发现。
+- 用户本地安装、模型选择、MCP 配置和会话偏好通过 WebDAV 持久化。
+
+这个方案的价值：
+
+- 不阻塞当前迭代。
+- 继续利用 GitHub PR 做社区审核和发布。
+- 不把密钥和用户私有配置放进公开仓库。
+- 给后续后端化保留清晰迁移边界。
+
+```plantuml
+@startuml
+title Chat Marketplace 渐进式架构
+
+actor 用户 as User
+
+rectangle "Chat 前端" as Chat {
+  component "发现页" as Discovery
+  component "技能会话/工作区" as SkillRuntime
+  component "本地配置管理" as LocalConfig
+}
+
+cloud "GitHub Marketplace 仓库" as GitHub {
+  database "skills/*.json\n技能包" as Skills
+  database "mcp/servers/*.json\nMCP 配置" as MCPPackages
+  database "providers/*.json\n模型供应商配置" as Providers
+  database "packages.json\n静态发布清单" as Packages
+}
+
+rectangle "模型服务" as Models {
+  component "Router\n主模型入口" as Router
+  component "第三方 Provider\n辅助入口" as ThirdParty
+}
+
+rectangle "MCP 服务" as MCP {
+  component "本地 MCP\nFetch / Filesystem / Git" as LocalMCP
+  component "第三方 MCP\nSearch / API / SaaS" as RemoteMCP
+}
+
+cloud "WebDAV" as WebDAV {
+  database "用户安装技能" as InstalledSkills
+  database "模型选择配置" as ModelConfig
+  database "MCP 本地配置" as MCPConfig
+  database "会话/偏好同步" as SyncData
+}
+
+User --> Discovery : 查找技能 / MCP / 模型
+Discovery --> GitHub : 拉取静态市场清单
+GitHub --> Discovery : 返回技能、MCP、Provider 配置
+
+User --> Discovery : 安装 / 启用
+Discovery --> LocalConfig : 写入本地运行配置
+LocalConfig --> WebDAV : 持久化配置
+
+User --> SkillRuntime : 使用技能
+SkillRuntime --> LocalConfig : 读取技能配置
+
+SkillRuntime --> Router : 默认模型请求
+SkillRuntime --> ThirdParty : 特殊模型请求
+
+SkillRuntime --> LocalMCP : 调用本地 MCP
+SkillRuntime --> RemoteMCP : 调用第三方 MCP
+
+LocalConfig --> WebDAV : 同步
+WebDAV --> LocalConfig : 恢复配置
+
+note right of GitHub
+  当前阶段继续使用 GitHub 管理静态数据：
+  - 技能包
+  - MCP 包
+  - Provider 配置
+  - 发布清单
+
+  不急于上完整后端。
+end note
+
+note bottom of Models
+  模型供应商策略：
+  Router 为主入口，
+  第三方 Provider 作为补充。
+end note
+
+note bottom of MCP
+  MCP 策略：
+  本地服务支持强能力和私有环境；
+  第三方服务通过 GitHub 配置发现。
+end note
+
+note bottom of WebDAV
+  用户侧配置通过 WebDAV 持久化：
+  - 已安装技能
+  - MCP 配置
+  - 模型偏好
+  - 会话与偏好
+end note
+
+@enduml
+```
+
+过渡阶段的边界：
+
+- GitHub 只保存公开、可审核、可复用的市场配置。
+- WebDAV 保存用户自己的安装状态、配置选择和同步数据。
+- Router 承担主要模型接入和能力路由。
+- 本地 MCP 承担需要本地环境、文件或私有网络的能力。
+- 第三方 MCP 和第三方 Provider 先作为可配置补充，不作为默认强依赖。
+
+当出现付费、企业授权、第三方发布后台和密钥托管需求时，再把 GitHub 静态市场逐步迁移到后端市场服务。
+
+## 4. 核心对象
+
+### 4.1 MarketItem
+
+市场项。用于描述一个可发现、可安装或可开通的能力。
+
+MarketItem 可以是：
+
+- `skill`：技能。
+- `mcp`：MCP 服务器。
+- `provider`：模型服务商。
+- `tool`：工具适配包。
+
+关键字段：
+
+```ts
+type MarketItem = {
+  id: string;
+  type: "skill" | "mcp" | "provider" | "tool";
+  version: string;
+  name: LocalizedText;
+  description: LocalizedText;
+  icon?: SkillIcon;
+  category?: string;
+  tags: string[];
+  publisher: {
+    id: string;
+    name: string;
+    verified: boolean;
+  };
+  pricing: {
+    type: "free" | "paid" | "subscription" | "usage" | "enterprise";
+    trial?: boolean;
+  };
+  visibility: {
+    scope: "public" | "organization" | "private";
+    organizationIds?: string[];
+    roles?: string[];
+  };
+  release: {
+    status: "draft" | "published" | "deprecated" | "removed";
+    review: "pending" | "approved" | "rejected";
+  };
+  manifest: SkillPackage | McpServerPackage | ProviderPackage | ToolPackage;
+};
+```
+
+产品规则：
+
+- 发现页展示 MarketItem，而不是直接展示底层 JSON 文件。
+- 第三方只能提交 MarketItem，不能直接进入全量用户市场。
+- `published + approved` 才能进入公共市场。
+
+### 4.2 Installation
+
+安装项。表示某个用户或组织已经安装了某个市场项。
+
+```ts
+type Installation = {
+  id: string;
+  itemId: string;
+  itemType: MarketItem["type"];
+  itemVersion: string;
+  ownerType: "user" | "organization";
+  ownerId: string;
+  installedBy: string;
+  installedAt: string;
+  status: "installed" | "disabled" | "removed";
+  configId?: string;
+};
+```
+
+产品规则：
+
+- 安装不等于可用。
+- 安装只说明用户或组织选择了这个能力。
+- 是否能运行，要看授权、模型、MCP、权限和 RuntimeConfig。
+- 已安装技能不应被市场版本静默覆盖。版本升级需要显式确认或组织策略。
+
+### 4.3 RuntimeConfig
+
+运行配置。表示某个安装项实际运行时使用的配置。
+
+```ts
+type RuntimeConfig = {
+  id: string;
+  installationId: string;
+  ownerType: "user" | "organization";
+  ownerId: string;
+  model?: {
+    providerName?: string;
+    model?: string;
+    endpointPath?: "/v1/responses" | "/v1/messages" | "/v1/chat/completions";
+    candidateCapabilities?: string[];
+  };
+  mcp?: Record<
+    string,
+    {
+      enabled: boolean;
+      status?: "active" | "paused" | "error" | "not_installed";
+      configRef?: string;
+    }
+  >;
+  tools?: Record<
+    string,
+    {
+      enabled: boolean;
+      configRef?: string;
+    }
+  >;
+  permissions: {
+    network: boolean;
+    filesystem: boolean;
+    wallet: boolean;
+    externalTools: string[];
+  };
+  secrets?: Record<string, { ref: string }>;
+  updatedAt: string;
+};
+```
+
+产品规则：
+
+- RuntimeConfig 可以来自组织默认配置，也可以被用户本地覆盖。
+- 密钥只保存引用，不把明文下发到前端。
+- 本地 MCP 仍由本机启动，但后端可以告诉前端缺什么、怎么配置。
+
+### 4.4 Entitlement
+
+授权项。表示用户或组织是否有权使用某个市场项。
+
+```ts
+type Entitlement = {
+  id: string;
+  itemId: string;
+  ownerType: "user" | "organization";
+  ownerId: string;
+  source: "free" | "trial" | "purchase" | "subscription" | "enterprise_grant";
+  status: "active" | "expired" | "revoked" | "pending";
+  startsAt?: string;
+  endsAt?: string;
+  usageLimit?: {
+    requests?: number;
+    tokens?: number;
+    period: "day" | "month" | "total";
+  };
+};
+```
+
+产品规则：
+
+- 免费技能也可以有 Entitlement，source 为 `free`。
+- 付费技能点击使用前必须检查 Entitlement。
+- 企业授权可以直接给组织，组织内用户继承。
+
+## 5. 用户流程
+
+### 5.1 发现技能
+
+1. 用户进入发现页。
+2. 前端请求 `GET /marketplace/items`。
+3. 后端返回当前用户可见的 MarketItem，以及安装状态、授权状态、运行状态摘要。
+4. 前端按状态展示：
+   - `可使用`
+   - `需配置`
+   - `需购买`
+   - `不可用`
+   - `已安装`
+
+### 5.2 点击技能
+
+点击技能后，不直接创建会话，而是先做运行检查。
+
+```txt
+点击技能
+  -> 检查授权
+  -> 检查安装
+  -> 检查模型
+  -> 检查 MCP
+  -> 检查权限
+  -> 生成运行计划
+```
+
+运行检查返回三类结果：
+
+```ts
+type RuntimeCheckResult = {
+  status: "ready" | "needs_config" | "needs_purchase" | "unavailable";
+  issues: RuntimeIssue[];
+  actions: RuntimeAction[];
+  launch?: {
+    type: "chat" | "workspace" | "external";
+    target?: string;
+    sessionConfig?: RuntimeConfig;
+  };
+};
+```
+
+用户体验：
+
+- `ready`：直接进入会话或工作区。
+- `needs_purchase`：打开购买或试用。
+- `needs_config`：打开配置向导。
+- `unavailable`：说明原因，例如组织未授权、本机不支持、市场项已下架。
+
+### 5.3 配置向导
+
+配置向导按缺口分步，不展示工程概念堆叠。
+
+推荐顺序：
+
+1. 授权：免费开通、试用、购买、企业授权。
+2. 模型：选择满足能力要求的模型。
+3. MCP：安装、启动、填写密钥或参数。
+4. 权限：确认网络、文件、钱包、外部工具权限。
+5. 完成：进入会话或工作区。
+
+示例：
+
+```txt
+网页调研
+当前缺少：
+- Brave Search API Key
+- Fetch MCP 未启动
+
+[配置 Brave Search] [启动 Fetch] [稍后再说]
+```
+
+### 5.4 使用技能
+
+进入会话后，Chat 应固定本次会话的运行配置：
+
+- 固定技能版本。
+- 固定 instructions。
+- 固定模型候选规则。
+- 固定 MCP 和工具范围。
+- 固定权限快照。
+
+市场项后续升级不应改变历史会话行为。
+
+## 6. API 设计
+
+### 6.1 发现市场
+
+```http
+GET /marketplace/items?type=skill&lang=cn
+```
+
+返回：
+
+```ts
+type MarketplaceItemView = {
+  item: MarketItem;
+  installed: boolean;
+  entitlementStatus: Entitlement["status"] | "none";
+  runtimeStatus: RuntimeCheckResult["status"];
+  runtimeSummary?: string;
+};
+```
+
+### 6.2 查看详情
+
+```http
+GET /marketplace/items/:itemId
+```
+
+用途：
+
+- 展示详情页。
+- 查看版本、发布者、价格、权限、依赖。
+- 做安装前确认。
+
+### 6.3 安装
+
+```http
+POST /installations
+```
+
+请求：
+
+```json
+{
+  "itemId": "web-research",
+  "ownerType": "user"
+}
+```
+
+返回 Installation。
+
+### 6.4 我的安装
+
+```http
+GET /installations
+```
+
+返回当前用户或组织可用的安装项。
+
+### 6.5 运行检查
+
+```http
+POST /runtime/check
+```
+
+请求：
+
+```json
+{
+  "itemId": "web-research",
+  "installationId": "inst_123",
+  "context": {
+    "platform": "web",
+    "lang": "cn"
+  }
+}
+```
+
+返回 RuntimeCheckResult。
+
+### 6.6 保存运行配置
+
+```http
+POST /runtime/configure
+```
+
+请求：
+
+```json
+{
+  "installationId": "inst_123",
+  "model": {
+    "providerName": "Router",
+    "model": "gpt-5.4",
+    "endpointPath": "/v1/responses"
+  },
+  "mcp": {
+    "fetch": {
+      "enabled": true
+    }
+  }
+}
+```
+
+返回 RuntimeConfig。
+
+### 6.7 授权和购买
+
+```http
+GET /entitlements?itemId=web-research
+POST /entitlements/trial
+POST /purchases
+```
+
+早期可以只实现 entitlement 状态，不立刻接支付。
+
+### 6.8 第三方发布
+
+```http
+POST /publisher/submissions
+GET /publisher/submissions/:id
+POST /publisher/submissions/:id/review
+```
+
+早期第三方发布仍可走 GitHub PR，后端只同步审核后的清单。
+
+## 7. 前端职责
+
+Chat 前端负责：
+
+- 展示发现页。
+- 展示配置向导。
+- 创建会话或打开工作区。
+- 启动本地 MCP。
+- 保存本地覆盖配置。
+- 执行模型请求和本地工具调用。
+
+Chat 前端不应该负责：
+
+- 判断付费授权真伪。
+- 审核第三方发布。
+- 保存明文密钥到公共配置。
+- 静态硬编码市场排序和推荐。
+- 兜底所有运行依赖错误。
+
+## 8. 后端职责
+
+后端负责：
+
+- 市场项聚合、审核、版本和上下架。
+- 用户或组织安装记录。
+- 授权、试用、购买状态。
+- 组织可见范围和员工权限。
+- 运行检查。
+- 敏感配置引用和密钥托管。
+- 市场统计、评分、推荐和风控。
+
+## 9. 与当前实现的关系
+
+当前实现可以保留：
+
+- `public/skill-packages.json`：内置技能包。
+- `yeying-community/marketplace`：社区公开发布源。
+- 发现页当前 UI。
+- 本地技能存储。
+- 本地 MCP 配置。
+
+需要调整：
+
+- 发现页数据源从纯 GitHub raw 变成后端 API 优先，GitHub raw 作为后端同步源或离线兜底。
+- 点击技能先调用 runtime check，再决定直接使用、配置、购买或展示不可用。
+- 安装社区技能后，如果需要配置，直接进入该技能的配置向导。
+- MCP 状态从“已配置”升级为“active / paused / error / not installed”。
+
+## 10. 迁移路径
+
+### 阶段 1：文档和前端状态收敛
+
+- 定义 MarketItem、Installation、RuntimeConfig、Entitlement。
+- 发现页按状态展示。
+- runtime check 先在前端本地实现。
+- 修复安装后不直达配置的问题。
+- MCP 检查 active 状态。
+
+### 阶段 2：最小后端
+
+- 实现市场列表 API。
+- 实现安装 API。
+- 实现运行检查 API。
+- 实现运行配置 API。
+- 后端从 GitHub marketplace 同步公开清单。
+
+### 阶段 3：组织和授权
+
+- 增加组织可见范围。
+- 增加企业授权。
+- 增加免费、试用、购买状态。
+- 前端发现页展示授权状态。
+
+### 阶段 4：第三方发布
+
+- 发布者身份。
+- 提交流程。
+- 审核流程。
+- 版本升级和下架。
+- 安全扫描和风险提示。
+
+### 阶段 5：商业化和推荐
+
+- 支付接入。
+- 用量统计。
+- 评分和评论。
+- 推荐排序。
+- 收入分成。
+
+## 11. 产品原则
+
+- 发现页不展示工程复杂度，只展示用户能做什么。
+- 配置向导只展示当前缺口，不展示全量设置。
+- 技能安装不代表可用，必须经过 runtime check。
+- 付费和授权由后端判断，前端只展示结果和引导。
+- 市场项版本升级不能静默改变历史会话。
+- MCP 和工具必须有明确权限边界。
+- 第三方发布必须先审核后上线。
+
+## 12. 下一步
+
+建议下一步先实现阶段 1：
+
+1. 把 runtime check 抽成统一函数，输出 `ready / needs_config / needs_purchase / unavailable`。
+2. 发现页点击技能时统一走 runtime check。
+3. 社区技能安装后，如果缺配置，直接打开该技能配置。
+4. MCP 依赖检查使用 active 状态，而不是只看配置是否存在。
+5. 为后端 API 预留 adapter，未来从本地 runtime check 平滑迁移到后端 runtime check。

--- a/test/plain-chat.test.ts
+++ b/test/plain-chat.test.ts
@@ -1,0 +1,76 @@
+import {
+  disablePlainChatReasoning,
+  isPlainChatSkill,
+} from "../app/utils/plain-chat";
+import { ServiceProvider } from "../app/constant";
+import type { ModelConfig } from "../app/store/config";
+import type { Skill } from "../app/store/skill";
+
+const modelConfig: ModelConfig = {
+  model: "gpt-5.4",
+  providerName: ServiceProvider.OpenAI,
+  temperature: 0.5,
+  top_p: 1,
+  max_tokens: 4000,
+  presence_penalty: 0,
+  frequency_penalty: 0,
+  reasoningMode: "on",
+  reasoningEffort: "high",
+  sendMemory: true,
+  historyMessageCount: 4,
+  compressMessageLengthThreshold: 1000,
+  compressModel: "",
+  compressProviderName: "",
+  enableInjectSystemPrompts: true,
+  template: "{{input}}",
+  size: "1024x1024",
+  quality: "auto",
+};
+
+const plainSkill: Skill = {
+  id: "plain",
+  avatar: "gpt-bot",
+  name: "新的聊天",
+  context: [],
+  syncGlobalConfig: true,
+  modelConfig,
+  candidateModels: [],
+  lang: "cn",
+  builtin: false,
+  createdAt: 1,
+  plugin: [],
+  tools: {
+    builtInTools: [],
+    mcpTools: [],
+    apiTools: [],
+  },
+};
+
+describe("plain chat reasoning isolation", () => {
+  test("disables reasoning for ordinary chat config", () => {
+    expect(disablePlainChatReasoning(modelConfig)).toMatchObject({
+      reasoningMode: "off",
+      reasoningEffort: "high",
+    });
+  });
+
+  test("detects ordinary chat skill", () => {
+    expect(isPlainChatSkill(plainSkill)).toBe(true);
+  });
+
+  test("does not treat prompted skill as ordinary chat", () => {
+    expect(
+      isPlainChatSkill({
+        ...plainSkill,
+        context: [
+          {
+            id: "system",
+            role: "system",
+            content: "Use deep reasoning.",
+            date: "",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});

--- a/test/skill-runtime.test.ts
+++ b/test/skill-runtime.test.ts
@@ -1,0 +1,104 @@
+import {
+  hasSkillMcpRuntimeIssue,
+  resolveSkillRuntimeStatus,
+} from "../app/skills/runtime";
+import { ServiceProvider } from "../app/constant";
+import type { LLMModel } from "../app/client/api";
+import type { ModelConfig } from "../app/store/config";
+import type { Skill } from "../app/store/skill";
+
+const model: LLMModel = {
+  name: "gpt-5.4",
+  available: true,
+  sorted: 1,
+  provider: {
+    id: "openai",
+    providerName: ServiceProvider.OpenAI,
+    providerType: "openai",
+    sorted: 1,
+  },
+};
+
+const modelConfig: ModelConfig = {
+  model: "gpt-5.4",
+  providerName: ServiceProvider.OpenAI,
+  temperature: 0.5,
+  top_p: 1,
+  max_tokens: 4000,
+  presence_penalty: 0,
+  frequency_penalty: 0,
+  reasoningMode: "off",
+  reasoningEffort: "medium",
+  sendMemory: true,
+  historyMessageCount: 4,
+  compressMessageLengthThreshold: 1000,
+  compressModel: "",
+  compressProviderName: "",
+  enableInjectSystemPrompts: true,
+  template: "{{input}}",
+  size: "1024x1024",
+  quality: "auto",
+};
+
+const baseSkill: Skill = {
+  id: "research",
+  avatar: "1f9e0",
+  name: "阅读总结",
+  context: [],
+  syncGlobalConfig: true,
+  modelConfig,
+  lang: "cn",
+  builtin: false,
+  createdAt: 1,
+  hideContext: false,
+  tools: {
+    mcpTools: ["fetch"],
+  },
+};
+
+function resolve(overrides: Parameters<typeof resolveSkillRuntimeStatus>[0]) {
+  return resolveSkillRuntimeStatus({
+    skill: baseSkill,
+    models: [model],
+    globalModelConfig: modelConfig,
+    installedPluginIds: [],
+    installedMcpServerIds: ["fetch"],
+    ...overrides,
+  });
+}
+
+describe("skill runtime checks", () => {
+  test("does not report inactive MCP before status is loaded", () => {
+    const result = resolve({});
+
+    expect(result.status).toBe("ready");
+    expect(hasSkillMcpRuntimeIssue(result)).toBe(false);
+  });
+
+  test("reports missing MCP configuration", () => {
+    const result = resolve({ installedMcpServerIds: [] });
+
+    expect(result.status).toBe("needs_config");
+    expect(result.issues).toEqual([
+      { type: "mcp_missing", message: "缺少 1 个 MCP 配置" },
+    ]);
+    expect(hasSkillMcpRuntimeIssue(result)).toBe(true);
+  });
+
+  test("reports configured but inactive MCP", () => {
+    const result = resolve({
+      mcpStatuses: {
+        fetch: {
+          status: "error",
+          errorMsg: "Request timeout",
+        },
+      },
+    });
+
+    expect(result.status).toBe("needs_config");
+    expect(result.issues).toEqual([
+      { type: "mcp_inactive", message: "1 个 MCP 未正常运行" },
+    ]);
+    expect(hasSkillMcpRuntimeIssue(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add marketplace runtime configuration plan
- route skill MCP runtime issues to MCP setup instead of generic skill config
- simplify the new chat skill entry and empty state
- keep deep reasoning isolated to the deep reasoning skill, not ordinary chats

## Tests
- npx eslint app/utils/plain-chat.ts app/store/skill.ts app/store/chat.ts app/components/chat.tsx test/plain-chat.test.ts
- npm run test:ci -- --runInBand test/plain-chat.test.ts test/reasoning-request.test.ts test/skill-runtime.test.ts