### PR TITLE
Add skill-specific session runtime controls

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -123,7 +123,11 @@ import {
 } from "../constant";
 import { Avatar } from "./emoji";
 import { ContextPrompts, SkillAvatar, SkillConfig } from "./mask";
-import { syncSkillLegacyPlugin, useSkillStore } from "../store/skill";
+import {
+  getSkillSessionToolbar,
+  syncSkillLegacyPlugin,
+  useSkillStore,
+} from "../store/skill";
 import { ChatCommandPrefix, useChatCommand, useCommand } from "../command";
 import { prettyObject } from "../utils/format";
 import { ExportMessageModal } from "./exporter";
@@ -541,6 +545,7 @@ export function ChatActions(props: {
   const pluginStore = usePluginStore();
   const session = chatStore.currentSession();
   const sessionSkill = session.mask;
+  const toolbar = getSkillSessionToolbar(sessionSkill);
   const { setAttachContents, setUploading } = props;
 
   // switch themes
@@ -649,7 +654,7 @@ export function ChatActions(props: {
   const isMobileScreen = useMobileScreen();
 
   useEffect(() => {
-    const show = isVisionModel(currentModel);
+    const show = toolbar.imageUpload && isVisionModel(currentModel);
     setShowUploadImage(show);
     if (!show) {
       setAttachContents([]);
@@ -698,6 +703,7 @@ export function ChatActions(props: {
     session,
     setAttachContents,
     setUploading,
+    toolbar.imageUpload,
   ]);
 
   return (
@@ -717,7 +723,7 @@ export function ChatActions(props: {
             icon={<BottomIcon />}
           />
         )}
-        {props.hitBottom && (
+        {props.hitBottom && toolbar.settings && (
           <ChatAction
             onClick={props.showPromptModal}
             text={Locale.Chat.InputActions.Settings}
@@ -725,65 +731,75 @@ export function ChatActions(props: {
           />
         )}
 
-        {showUploadImage && (
+        {toolbar.imageUpload && showUploadImage && (
           <ChatAction
             onClick={props.uploadImage}
             text={Locale.Chat.InputActions.UploadImage}
             icon={props.uploading ? <LoadingButtonIcon /> : <ImageIcon />}
           />
         )}
-        <ChatAction
-          onClick={nextTheme}
-          text={Locale.Chat.InputActions.Theme[theme]}
-          icon={
-            <>
-              {theme === Theme.Auto ? (
-                <AutoIcon />
-              ) : theme === Theme.Light ? (
-                <LightIcon />
-              ) : theme === Theme.Dark ? (
-                <DarkIcon />
-              ) : null}
-            </>
-          }
-        />
+        {toolbar.theme && (
+          <ChatAction
+            onClick={nextTheme}
+            text={Locale.Chat.InputActions.Theme[theme]}
+            icon={
+              <>
+                {theme === Theme.Auto ? (
+                  <AutoIcon />
+                ) : theme === Theme.Light ? (
+                  <LightIcon />
+                ) : theme === Theme.Dark ? (
+                  <DarkIcon />
+                ) : null}
+              </>
+            }
+          />
+        )}
 
-        <ChatAction
-          onClick={props.showPromptHints}
-          text={Locale.Chat.InputActions.Prompt}
-          icon={<PromptIcon />}
-        />
+        {toolbar.promptHints && (
+          <ChatAction
+            onClick={props.showPromptHints}
+            text={Locale.Chat.InputActions.Prompt}
+            icon={<PromptIcon />}
+          />
+        )}
 
-        <ChatAction
-          onClick={() => {
-            navigate(Path.Skills);
-          }}
-          text={Locale.Chat.InputActions.Masks}
-          icon={<MaskIcon />}
-        />
+        {toolbar.skillSwitcher && (
+          <ChatAction
+            onClick={() => {
+              navigate(Path.Skills);
+            }}
+            text={Locale.Chat.InputActions.Masks}
+            icon={<MaskIcon />}
+          />
+        )}
 
-        <ChatAction
-          text={Locale.Chat.InputActions.Clear}
-          icon={<BreakIcon />}
-          onClick={() => {
-            chatStore.updateTargetSession(session, (session) => {
-              if (session.clearContextIndex === session.messages.length) {
-                session.clearContextIndex = undefined;
-              } else {
-                session.clearContextIndex = session.messages.length;
-                session.memoryPrompt = ""; // will clear memory
-              }
-            });
-          }}
-        />
+        {toolbar.clearContext && (
+          <ChatAction
+            text={Locale.Chat.InputActions.Clear}
+            icon={<BreakIcon />}
+            onClick={() => {
+              chatStore.updateTargetSession(session, (session) => {
+                if (session.clearContextIndex === session.messages.length) {
+                  session.clearContextIndex = undefined;
+                } else {
+                  session.clearContextIndex = session.messages.length;
+                  session.memoryPrompt = ""; // will clear memory
+                }
+              });
+            }}
+          />
+        )}
 
-        <ChatAction
-          onClick={() => setShowModelSelector(true)}
-          text={currentModelName}
-          icon={<RobotIcon />}
-        />
+        {toolbar.modelSelector && (
+          <ChatAction
+            onClick={() => setShowModelSelector(true)}
+            text={currentModelName}
+            icon={<RobotIcon />}
+          />
+        )}
 
-        {showModelSelector && (
+        {toolbar.modelSelector && showModelSelector && (
           <Selector
             defaultSelectedValue={`${currentModel}@${currentProviderName}`}
             items={modelSelectorItems}
@@ -817,7 +833,7 @@ export function ChatActions(props: {
           />
         )}
 
-        {supportsCustomSize(currentModel) && (
+        {toolbar.imageParams && supportsCustomSize(currentModel) && (
           <ChatAction
             onClick={() => setShowSizeSelector(true)}
             text={currentSize}
@@ -845,7 +861,7 @@ export function ChatActions(props: {
           />
         )}
 
-        {qualityOptions.length > 0 && (
+        {toolbar.imageParams && qualityOptions.length > 0 && (
           <ChatAction
             onClick={() => setShowQualitySelector(true)}
             text={currentQuality}
@@ -873,7 +889,7 @@ export function ChatActions(props: {
           />
         )}
 
-        {isDalle3(currentModel) && (
+        {toolbar.imageParams && isDalle3(currentModel) && (
           <ChatAction
             onClick={() => setShowStyleSelector(true)}
             text={currentStyle}
@@ -901,7 +917,7 @@ export function ChatActions(props: {
           />
         )}
 
-        {showPlugins(currentProviderName, currentModel) && (
+        {toolbar.plugins && showPlugins(currentProviderName, currentModel) && (
           <ChatAction
             onClick={() => {
               if (pluginStore.getAll().length == 0) {
@@ -935,17 +951,17 @@ export function ChatActions(props: {
           />
         )}
 
-        {!isMobileScreen && (
+        {!isMobileScreen && toolbar.shortcutKeys && (
           <ChatAction
             onClick={() => props.setShowShortcutKeyModal(true)}
             text={Locale.Chat.ShortcutKey.Title}
             icon={<ShortcutkeyIcon />}
           />
         )}
-        {!isMobileScreen && <MCPAction />}
+        {!isMobileScreen && toolbar.mcp && <MCPAction />}
       </>
       <div className={styles["chat-input-actions-end"]}>
-        {config.realtimeConfig.enable && (
+        {toolbar.realtime && config.realtimeConfig.enable && (
           <ChatAction
             onClick={() => props.setShowChatSidePanel(true)}
             text={"Realtime Chat"}

--- a/app/components/discovery.tsx
+++ b/app/components/discovery.tsx
@@ -40,6 +40,7 @@ import ModelServiceIcon from "../icons/llm-icons/default.svg";
 import ToolIcon from "../icons/tool.svg";
 import styles from "./discovery.module.scss";
 import { useAccessStore } from "../store/access";
+import { useSdStore } from "../store/sd";
 import {
   getSkillRuntimeIssueSummary,
   getSkillRuntimeStatusOrder,
@@ -113,6 +114,7 @@ function getCapabilityIcon(type: Capability["type"]) {
 export function DiscoveryPage() {
   const navigate = useNavigate();
   const chatStore = useChatStore();
+  const sdStore = useSdStore();
   const location = useLocation();
   const view = getInitialView(location.search);
   const activeType = getInitialType(location.search);
@@ -531,6 +533,7 @@ export function DiscoveryPage() {
 
   const startSkill = (skill: Skill) => {
     if (skill.launch?.type === "sd") {
+      sdStore.startBlankCreation();
       navigate(Path.Sd);
       return;
     }

--- a/app/components/discovery.tsx
+++ b/app/components/discovery.tsx
@@ -529,6 +529,17 @@ export function DiscoveryPage() {
     return matchType && matchView && matchSearch;
   });
 
+  const startSkill = (skill: Skill) => {
+    if (skill.launch?.type === "sd") {
+      navigate(Path.Sd);
+      return;
+    }
+
+    if (chatStore.newSession(skill) !== false) {
+      navigate(Path.Chat);
+    }
+  };
+
   const handleCapabilityAction = (item: Capability) => {
     if (item.type === "skill" && item.skillPackage && item.skillPackageLang) {
       const skill = skillPackageToSkill(
@@ -540,9 +551,7 @@ export function DiscoveryPage() {
       const installedSkill = useSkillStore.getState().create(skill);
 
       if (item.runtimeStatus === "ready") {
-        if (chatStore.newSession(installedSkill) !== false) {
-          navigate(Path.Chat);
-        }
+        startSkill(installedSkill);
       } else if (hasSkillMcpRuntimeIssue(item.runtimeResult)) {
         navigate(Path.McpMarket);
       } else {
@@ -560,9 +569,7 @@ export function DiscoveryPage() {
         openSkillConfig(item.skill);
         return;
       }
-      if (chatStore.newSession(item.skill) !== false) {
-        navigate(Path.Chat);
-      }
+      startSkill(item.skill);
       return;
     }
     navigate(item.path);

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -959,7 +959,7 @@ export function SkillPage() {
 
   const startSkill = (skill: Skill) => {
     if (skill.launch?.type === "sd") {
-      sdStore.setCurrentMode("generation");
+      sdStore.startBlankCreation();
       navigate(Path.Sd);
       return;
     }

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -23,6 +23,7 @@ import {
   syncSkillLegacyPlugin,
   useSkillStore,
 } from "../store/skill";
+import { useSdStore } from "../store/sd";
 import {
   ChatMessage,
   createMessage,
@@ -906,6 +907,7 @@ export function SkillPage() {
 
   const skillStore = useSkillStore();
   const chatStore = useChatStore();
+  const sdStore = useSdStore();
 
   const filterLang = skillStore.language;
 
@@ -952,6 +954,18 @@ export function SkillPage() {
     setEditingSkillId(undefined);
     if (new URLSearchParams(location.search).has("skill")) {
       navigate(Path.Skills, { replace: true });
+    }
+  };
+
+  const startSkill = (skill: Skill) => {
+    if (skill.launch?.type === "sd") {
+      sdStore.setCurrentMode("generation");
+      navigate(Path.Sd);
+      return;
+    }
+
+    if (chatStore.newSession(skill) !== false) {
+      navigate(Path.Chat);
     }
   };
 
@@ -1145,11 +1159,7 @@ export function SkillPage() {
                   <IconButton
                     icon={<AddIcon />}
                     text={Locale.Mask.Item.Chat}
-                    onClick={() => {
-                      if (chatStore.newSession(m) !== false) {
-                        navigate(Path.Chat);
-                      }
-                    }}
+                    onClick={() => startSkill(m)}
                   />
                   {m.builtin ? (
                     <IconButton

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -358,22 +358,23 @@ export function NewChat() {
   };
   const startSkill = (skill?: Skill) => {
     if (!skill) return;
-    const runtime = skillRuntimeMap.get(getSkillEntryKey(skill));
-    if (runtime && runtime.status !== "ready") {
-      navigate(hasSkillMcpRuntimeIssue(runtime) ? Path.McpMarket : Path.Skills);
-      return;
-    }
 
     if (skill.launch?.type === "sd") {
       const input = draft.trim();
-      sdStore.setCurrentMode("generation");
       if (input) {
+        sdStore.setCurrentMode("generation");
         sdStore.setCurrentParams({
           ...useSdStore.getState().currentParams,
           prompt: input,
         });
       }
       navigate(Path.Sd);
+      return;
+    }
+
+    const runtime = skillRuntimeMap.get(getSkillEntryKey(skill));
+    if (runtime && runtime.status !== "ready") {
+      navigate(hasSkillMcpRuntimeIssue(runtime) ? Path.McpMarket : Path.Skills);
       return;
     }
 

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -361,13 +361,7 @@ export function NewChat() {
 
     if (skill.launch?.type === "sd") {
       const input = draft.trim();
-      if (input) {
-        sdStore.setCurrentMode("generation");
-        sdStore.setCurrentParams({
-          ...useSdStore.getState().currentParams,
-          prompt: input,
-        });
-      }
+      sdStore.startBlankCreation(input);
       navigate(Path.Sd);
       return;
     }

--- a/app/components/sd/image-registry.ts
+++ b/app/components/sd/image-registry.ts
@@ -44,7 +44,8 @@ function buildRuntimeImageModelForMode(
 ): ImageModelDefinition | null {
   const tags = model.tags ?? [];
   const endpoints = model.supportedEndpoints ?? [];
-  if (!tags.includes("image")) return null;
+  const modelType = model.modelType?.trim().toLowerCase();
+  if (!tags.includes("image") && modelType !== "image") return null;
   const endpointType: ImageEndpointType =
     mode === "editing" ? "images-edits" : "images-generation";
   const isSupported =

--- a/app/components/sd/sd-sidebar.tsx
+++ b/app/components/sd/sd-sidebar.tsx
@@ -41,6 +41,7 @@ export function SideBar(props: { className?: string }) {
   const currentModel = sdStore.currentModel;
   const params = sdStore.currentParams;
   const setParams = sdStore.setCurrentParams;
+  const currentSessionId = sdStore.currentSessionId;
   const paramColumns = getParams?.(currentModel, params) || [];
   const hasModelSelection = !!currentModel.value && paramColumns.length > 0;
   const canSubmit =
@@ -80,6 +81,7 @@ export function SideBar(props: { className?: string }) {
       provider: currentModel.provider || "",
       provider_name: currentModel.providerName || "",
       endpoint_type: currentModel.endpointType || "",
+      session_id: currentSessionId,
       model_def: currentModel,
       model: currentModel.value,
       model_name: currentModel.name,

--- a/app/components/sd/sd.tsx
+++ b/app/components/sd/sd.tsx
@@ -6,7 +6,7 @@ import { IconButton } from "@/app/components/button";
 import ReturnIcon from "@/app/icons/return.svg";
 import Locale from "@/app/locales";
 import { Path, CACHE_URL_PREFIX } from "@/app/constant";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import {
   copyToClipboard,
   getMessageTextContent,
@@ -98,13 +98,33 @@ export function Sd() {
   const config = useAppConfig();
   const scrollRef = useRef<HTMLDivElement>(null);
   const sdStore = useSdStore();
-  const [sdImages, setSdImages] = useState(sdStore.draw);
+  const currentSessionId = sdStore.currentSessionId;
+  const setCurrentSessionId = sdStore.setCurrentSessionId;
   const isSd = location.pathname === Path.Sd;
   const selectedTaskId = new URLSearchParams(location.search).get("task");
+  const selectedTask = useMemo(
+    () => sdStore.draw.find((item: any) => item.id === selectedTaskId),
+    [sdStore.draw, selectedTaskId],
+  );
+  const activeSessionId =
+    selectedTaskId && selectedTask
+      ? selectedTask.session_id || ""
+      : currentSessionId || "";
+  const selectedTaskSessionId = selectedTask?.session_id || "";
+  const sdImages = useMemo(() => {
+    if (!activeSessionId) {
+      return sdStore.draw.filter((item: any) => !item.session_id);
+    }
+    return sdStore.draw.filter(
+      (item: any) => item.session_id === activeSessionId,
+    );
+  }, [activeSessionId, sdStore.draw]);
 
   useEffect(() => {
-    setSdImages(sdStore.draw);
-  }, [sdStore.currentId, sdStore.draw]);
+    if (selectedTaskSessionId && currentSessionId !== selectedTaskSessionId) {
+      setCurrentSessionId(selectedTaskSessionId);
+    }
+  }, [currentSessionId, selectedTaskSessionId, setCurrentSessionId]);
 
   useEffect(() => {
     if (!selectedTaskId) return;
@@ -296,6 +316,8 @@ export function Sd() {
                                 provider: item.provider,
                                 provider_name: item.provider_name,
                                 endpoint_type: item.endpoint_type,
+                                session_id:
+                                  item.session_id || activeSessionId || "",
                                 model_def: item.model_def,
                                 model: item.model,
                                 model_name: item.model_name,
@@ -315,6 +337,9 @@ export function Sd() {
                               bordered
                               title={Locale.Sd.Actions.EditAgain}
                               onClick={() => {
+                                if (item.session_id) {
+                                  sdStore.setCurrentSessionId(item.session_id);
+                                }
                                 sdStore.setCurrentMode("editing");
                                 sdStore.setEditSourceType("history");
                                 if (item.model_def) {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -26,7 +26,7 @@ const cn = {
     Confirm: "确认",
     Later: "稍后再说",
     TopTips:
-      "🥳 Chat AI 首发，立刻解锁 qwen3.7-max、deepseek-v4-pro、gpt-5.5、claude-4.8等最新大模型",
+      "🥳 Chat AI 首发，立刻解锁 qwen3.7-plus、deepseek-v4-pro、gpt-5.5、claude-4.8等最新大模型",
   },
   ChatItem: {
     ChatItemCount: (count: number) => `${count} 条对话`,

--- a/app/skills/cn.ts
+++ b/app/skills/cn.ts
@@ -1,5 +1,5 @@
 import { BuiltinSkill } from "./typing";
-import { createBuiltinSkill } from "./utils";
+import { CHAT_TOOLBAR_PRESETS, createBuiltinSkill } from "./utils";
 import { ServiceProvider } from "../constant";
 
 export const CN_SKILLS: BuiltinSkill[] = [
@@ -15,6 +15,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "cn",
     createdAt: 1700000001001,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.general,
+    },
     context: [
       {
         id: "cn-general-0",
@@ -41,6 +44,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "cn",
     createdAt: 1700000001002,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.research,
+    },
     context: [
       {
         id: "cn-web-research-0",
@@ -68,6 +74,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "cn",
     createdAt: 1700000001003,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.research,
+    },
     context: [
       {
         id: "cn-reading-0",
@@ -95,6 +104,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "cn",
     createdAt: 1700000001004,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.research,
+    },
     context: [
       {
         id: "cn-compare-0",
@@ -128,6 +140,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     toolStrategy: {
       nativeMcpTools: "auto",
     },
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.reasoning,
+    },
     context: [
       {
         id: "cn-deep-reasoning-0",
@@ -159,6 +174,9 @@ export const CN_SKILLS: BuiltinSkill[] = [
     createdAt: 1700000001005,
     syncGlobalConfig: false,
     launch: { type: "sd" },
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.image,
+    },
     context: [
       {
         id: "cn-image-0",

--- a/app/skills/en.ts
+++ b/app/skills/en.ts
@@ -1,5 +1,5 @@
 import { BuiltinSkill } from "./typing";
-import { createBuiltinSkill } from "./utils";
+import { CHAT_TOOLBAR_PRESETS, createBuiltinSkill } from "./utils";
 import { ServiceProvider } from "../constant";
 
 export const EN_SKILLS: BuiltinSkill[] = [
@@ -16,6 +16,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "en",
     createdAt: 1700000002001,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.general,
+    },
     context: [
       {
         id: "en-general-0",
@@ -43,6 +46,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "en",
     createdAt: 1700000002002,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.research,
+    },
     context: [
       {
         id: "en-web-research-0",
@@ -71,6 +77,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "en",
     createdAt: 1700000002003,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.research,
+    },
     context: [
       {
         id: "en-reading-0",
@@ -99,6 +108,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     ],
     lang: "en",
     createdAt: 1700000002004,
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.research,
+    },
     context: [
       {
         id: "en-compare-0",
@@ -132,6 +144,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     toolStrategy: {
       nativeMcpTools: "auto",
     },
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.reasoning,
+    },
     context: [
       {
         id: "en-deep-reasoning-0",
@@ -164,6 +179,9 @@ export const EN_SKILLS: BuiltinSkill[] = [
     createdAt: 1700000002005,
     syncGlobalConfig: false,
     launch: { type: "sd" },
+    ui: {
+      sessionToolbar: CHAT_TOOLBAR_PRESETS.image,
+    },
     context: [
       {
         id: "en-image-0",

--- a/app/skills/package.ts
+++ b/app/skills/package.ts
@@ -2,7 +2,11 @@ import type { ModelCandidate } from "../client/api";
 import type { Lang } from "../locales";
 import type { ChatMessage } from "../store/chat";
 import type { ModelConfig } from "../store/config";
-import type { BuiltInSkillToolType, Skill } from "../store/skill";
+import type {
+  BuiltInSkillToolType,
+  Skill,
+  SkillSessionToolbarConfig,
+} from "../store/skill";
 import type { BuiltinSkill } from "./typing";
 
 export type LocalizedText = string | Partial<Record<Lang, string>>;
@@ -91,6 +95,7 @@ export type SkillPackage = {
   ui?: {
     entryLabel?: LocalizedText;
     emptyState?: "minimal" | "guided";
+    sessionToolbar?: SkillSessionToolbarConfig;
   };
   permissions?: SkillPermissions;
   compatibility?: {
@@ -209,6 +214,7 @@ export function skillPackageToSkill(
       mcpTools: skillPackage.mcp?.servers?.map((server) => server.id) ?? [],
       apiTools,
     },
+    ui: skillPackage.ui,
     launch: resolveLegacyLaunch(skillPackage.launch),
   };
   syncSkillLegacyPlugin(skill);
@@ -293,6 +299,7 @@ export function skillToSkillPackage(skill: Skill | BuiltinSkill): SkillPackage {
         required: false,
       })),
     },
+    ui: skill.ui,
     permissions: {
       network: false,
       filesystem: false,

--- a/app/skills/runtime.ts
+++ b/app/skills/runtime.ts
@@ -100,6 +100,7 @@ export function resolveSkillRuntimeStatus(params: {
         ...globalModelConfig,
         ...skill.modelConfig,
       };
+  const usesWorkspaceRuntime = skill.launch?.type === "sd";
   const hasCandidateModelRestriction = candidateModels.length > 0;
   const hasCurrentModel = sessionModels.some((model) =>
     matchesModelCandidate(model, {
@@ -124,7 +125,7 @@ export function resolveSkillRuntimeStatus(params: {
 
   const issues: SkillRuntimeIssue[] = [];
 
-  if (runtimeModels.length === 0) {
+  if (!usesWorkspaceRuntime && runtimeModels.length === 0) {
     issues.push({
       type: "model",
       message: "当前没有任何可用模型",
@@ -135,7 +136,11 @@ export function resolveSkillRuntimeStatus(params: {
     };
   }
 
-  if (hasCandidateModelRestriction && sessionModels.length === 0) {
+  if (
+    !usesWorkspaceRuntime &&
+    hasCandidateModelRestriction &&
+    sessionModels.length === 0
+  ) {
     issues.push({
       type: "model",
       message: "候选模型当前都不可用",
@@ -146,7 +151,11 @@ export function resolveSkillRuntimeStatus(params: {
     };
   }
 
-  if (!hasCandidateModelRestriction && !hasCurrentModel) {
+  if (
+    !usesWorkspaceRuntime &&
+    !hasCandidateModelRestriction &&
+    !hasCurrentModel
+  ) {
     issues.push({
       type: "model",
       message: "默认模型需要调整",

--- a/app/skills/utils.ts
+++ b/app/skills/utils.ts
@@ -2,6 +2,7 @@ import { Lang } from "../locales";
 import { type ModelConfig } from "../store/config";
 import { type ChatMessage } from "../store/chat";
 import { type BuiltinSkill } from "./typing";
+import type { SkillSessionToolbarConfig } from "../store/skill";
 
 type BuiltinSkillInput = {
   avatar: string;
@@ -15,6 +16,7 @@ type BuiltinSkillInput = {
   syncGlobalConfig?: boolean;
   candidateModels?: BuiltinSkill["candidateModels"];
   toolStrategy?: BuiltinSkill["toolStrategy"];
+  ui?: BuiltinSkill["ui"];
   launch?: BuiltinSkill["launch"];
   modelConfig?: Partial<ModelConfig>;
 };
@@ -28,6 +30,65 @@ const DEFAULT_MODEL_CONFIG: Partial<ModelConfig> = {
   historyMessageCount: 8,
   compressMessageLengthThreshold: 2000,
 };
+
+export const CHAT_TOOLBAR_PRESETS = {
+  general: {
+    settings: true,
+    theme: true,
+    promptHints: true,
+    skillSwitcher: true,
+    clearContext: true,
+    modelSelector: true,
+    imageUpload: true,
+    imageParams: false,
+    plugins: true,
+    mcp: true,
+    shortcutKeys: true,
+    realtime: true,
+  },
+  research: {
+    settings: true,
+    theme: true,
+    promptHints: true,
+    skillSwitcher: true,
+    clearContext: true,
+    modelSelector: true,
+    imageUpload: true,
+    imageParams: false,
+    plugins: false,
+    mcp: true,
+    shortcutKeys: true,
+    realtime: false,
+  },
+  reasoning: {
+    settings: true,
+    theme: false,
+    promptHints: true,
+    skillSwitcher: true,
+    clearContext: true,
+    modelSelector: true,
+    imageUpload: false,
+    imageParams: false,
+    plugins: false,
+    mcp: false,
+    shortcutKeys: true,
+    realtime: false,
+  },
+  image: {
+    settings: false,
+    theme: false,
+    promptHints: true,
+    skillSwitcher: true,
+    clearContext: false,
+    modelSelector: true,
+    imageUpload: true,
+    imageParams: true,
+    plugins: false,
+    mcp: false,
+    shortcutKeys: false,
+    realtime: false,
+  },
+} satisfies Record<string, SkillSessionToolbarConfig>;
 
 export function createBuiltinSkill(input: BuiltinSkillInput): BuiltinSkill {
   return {

--- a/app/store/sd.ts
+++ b/app/store/sd.ts
@@ -133,6 +133,7 @@ export const useSdStore = createPersistStore<
     setEditMaskImage: (image: string, name?: string) => void;
     setCurrentModel: (model: any) => void;
     setCurrentParams: (data: any) => void;
+    startBlankCreation: (prompt?: string) => void;
     deleteDraw: (id: string) => void;
   }
 >(
@@ -290,6 +291,25 @@ export const useSdStore = createPersistStore<
       setCurrentParams(data: any) {
         set({
           currentParams: data,
+        });
+      },
+      startBlankCreation(prompt = "") {
+        const currentModel = _get().currentModel;
+        const currentParams = getModelParamBasicData(
+          currentModel?.params?.({}) ?? [],
+          {},
+        );
+        set({
+          currentMode: "generation",
+          editSourceType: "history",
+          editSourceImage: "",
+          editSourceName: "",
+          editMaskImage: "",
+          editMaskName: "",
+          currentParams: {
+            ...currentParams,
+            prompt,
+          },
         });
       },
     };

--- a/app/store/sd.ts
+++ b/app/store/sd.ts
@@ -99,6 +99,7 @@ const defaultParams = getModelParamBasicData(defaultModel.params({}), {});
 
 const DEFAULT_SD_STATE = {
   currentId: 0,
+  currentSessionId: "",
   draw: [],
   currentMode: "generation" as ImageFormMode,
   editSourceType: "history" as "history" | "upload",
@@ -113,6 +114,7 @@ const DEFAULT_SD_STATE = {
 export const useSdStore = createPersistStore<
   {
     currentId: number;
+    currentSessionId: string;
     draw: any[];
     currentMode: ImageFormMode;
     editSourceType: "history" | "upload";
@@ -133,6 +135,7 @@ export const useSdStore = createPersistStore<
     setEditMaskImage: (image: string, name?: string) => void;
     setCurrentModel: (model: any) => void;
     setCurrentParams: (data: any) => void;
+    setCurrentSessionId: (sessionId: string) => void;
     startBlankCreation: (prompt?: string) => void;
     deleteDraw: (id: string) => void;
   }
@@ -153,10 +156,17 @@ export const useSdStore = createPersistStore<
         return id;
       },
       sendTask(data: any, okCall?: Function) {
-        data = { ...data, id: nanoid(), status: "running" };
-        set({ draw: [data, ..._get().draw] });
-        this.getNextId();
-        this.imageGenerationRequestCall(data);
+        const sessionId =
+          data.session_id || _get().currentSessionId || nanoid();
+        data = {
+          ...data,
+          id: nanoid(),
+          session_id: sessionId,
+          status: "running",
+        };
+        set({ currentSessionId: sessionId, draw: [data, ..._get().draw] });
+        get().getNextId();
+        get().imageGenerationRequestCall(data);
         okCall?.();
       },
       async imageGenerationRequestCall(data: any) {
@@ -205,23 +215,23 @@ export const useSdStore = createPersistStore<
           .then((resData) => {
             const errorMessage = schema.resolveErrorMessage(resData);
             if (errorMessage) {
-              this.updateDraw({
+              get().updateDraw({
                 ...data,
                 status: "error",
                 error: normalizeSdErrorMessage(errorMessage),
               });
-              this.getNextId();
+              get().getNextId();
               return;
             }
 
             const imageResult = schema.resolveImageResult(resData);
             if (!imageResult) {
-              this.updateDraw({
+              get().updateDraw({
                 ...data,
                 status: "error",
                 error: normalizeSdErrorMessage(JSON.stringify(resData)),
               });
-              this.getNextId();
+              get().getNextId();
               return;
             }
 
@@ -232,46 +242,43 @@ export const useSdStore = createPersistStore<
 
             imagePromise
               .then((img_data: string) => {
-                this.updateDraw({
+                get().updateDraw({
                   ...data,
                   status: "success",
                   img_data,
                 });
               })
               .catch((e) => {
-                this.updateDraw({
+                get().updateDraw({
                   ...data,
                   status: "error",
                   error: normalizeSdErrorMessage(JSON.stringify(e)),
                 });
               })
               .finally(() => {
-                this.getNextId();
+                get().getNextId();
               });
           })
           .catch((error) => {
-            this.updateDraw({
+            get().updateDraw({
               ...data,
               status: "error",
               error: normalizeSdErrorMessage(error.message),
             });
             console.error("Error:", error);
-            this.getNextId();
+            get().getNextId();
           });
       },
       updateDraw(_draw: any) {
         const draw = _get().draw || [];
-        draw.some((item, index) => {
-          if (item.id === _draw.id) {
-            draw[index] = _draw;
-            set(() => ({ draw }));
-            return true;
-          }
-        });
+        const nextDraw = draw.map((item) =>
+          item.id === _draw.id ? _draw : item,
+        );
+        set({ draw: nextDraw });
       },
       deleteDraw(id: string) {
         set({ draw: (_get().draw || []).filter((item) => item.id !== id) });
-        this.getNextId();
+        get().getNextId();
       },
       setCurrentMode(mode: ImageFormMode) {
         set({ currentMode: mode });
@@ -293,13 +300,18 @@ export const useSdStore = createPersistStore<
           currentParams: data,
         });
       },
+      setCurrentSessionId(sessionId: string) {
+        set({ currentSessionId: sessionId });
+      },
       startBlankCreation(prompt = "") {
         const currentModel = _get().currentModel;
+        const sessionId = nanoid();
         const currentParams = getModelParamBasicData(
           currentModel?.params?.({}) ?? [],
           {},
         );
         set({
+          currentSessionId: sessionId,
           currentMode: "generation",
           editSourceType: "history",
           editSourceImage: "",

--- a/app/store/skill.ts
+++ b/app/store/skill.ts
@@ -22,6 +22,25 @@ export type SkillToolStrategy = {
   nativeMcpTools?: SkillNativeMcpToolsMode;
 };
 
+export type SkillSessionToolbarConfig = {
+  settings?: boolean;
+  theme?: boolean;
+  promptHints?: boolean;
+  skillSwitcher?: boolean;
+  clearContext?: boolean;
+  modelSelector?: boolean;
+  imageUpload?: boolean;
+  imageParams?: boolean;
+  plugins?: boolean;
+  mcp?: boolean;
+  shortcutKeys?: boolean;
+  realtime?: boolean;
+};
+
+export type SkillUiConfig = {
+  sessionToolbar?: SkillSessionToolbarConfig;
+};
+
 export type Skill = {
   id: string;
   packageId?: string;
@@ -41,12 +60,35 @@ export type Skill = {
   plugin?: string[];
   tools?: SkillToolsConfig;
   toolStrategy?: SkillToolStrategy;
+  ui?: SkillUiConfig;
   enableArtifacts?: boolean;
   enableCodeFold?: boolean;
   launch?: {
     type: "chat" | "sd";
   };
 };
+
+export const DEFAULT_SESSION_TOOLBAR: Required<SkillSessionToolbarConfig> = {
+  settings: true,
+  theme: true,
+  promptHints: true,
+  skillSwitcher: true,
+  clearContext: true,
+  modelSelector: true,
+  imageUpload: true,
+  imageParams: true,
+  plugins: true,
+  mcp: true,
+  shortcutKeys: true,
+  realtime: true,
+};
+
+export function getSkillSessionToolbar(skill: Skill) {
+  return {
+    ...DEFAULT_SESSION_TOOLBAR,
+    ...skill.ui?.sessionToolbar,
+  };
+}
 
 export const DEFAULT_SKILL_STATE = {
   skills: {} as Record<string, Skill>,
@@ -81,6 +123,9 @@ export const createEmptySkill = () =>
     },
     toolStrategy: {
       nativeMcpTools: "auto",
+    },
+    ui: {
+      sessionToolbar: DEFAULT_SESSION_TOOLBAR,
     },
   }) as Skill;
 

--- a/docs/技能规范.md
+++ b/docs/技能规范.md
@@ -246,6 +246,35 @@ type SkillPermissions = {
 - 首次运行高风险能力时二次确认。
 - 管理员可以限制组织成员安装或运行某些权限的技能。
 
+### 会话界面
+
+技能需要声明自己的会话工具条，而不是默认复用普通对话的全部按钮。
+
+```ts
+type SkillSessionToolbar = {
+  settings?: boolean;
+  theme?: boolean;
+  promptHints?: boolean;
+  skillSwitcher?: boolean;
+  clearContext?: boolean;
+  modelSelector?: boolean;
+  imageUpload?: boolean;
+  imageParams?: boolean;
+  plugins?: boolean;
+  mcp?: boolean;
+  shortcutKeys?: boolean;
+  realtime?: boolean;
+};
+```
+
+产品原则：
+
+- 普通问答可以保留完整工具条。
+- 阅读、调研、对比类技能应突出模型、MCP 和提示入口，减少插件、实时语音等无关按钮。
+- 深度思考类技能应保持聚焦，默认隐藏图片上传、插件、MCP 和主题切换。
+- 图片创作类技能应进入专属工作区，并只暴露模型、图片上传、尺寸、质量等创作相关参数。
+- 技能缺少必需模型、MCP 或工具时，不应让用户在会话里试探，应在启动前或工具条区域明确提示。
+
 ### 可见范围
 
 ```ts

--- a/docs/技能规范.md
+++ b/docs/技能规范.md
@@ -136,6 +136,36 @@ type SkillLaunch =
 - 图片创作使用 `workspace:sd`。
 - 后续代码执行、知识库、报表等可以扩展专属 workspace。
 
+### 会话运行模型
+
+技能启动后只有两种产品形态：
+
+- 独立会话页：技能进入专属工作区。适用于图片创作、代码执行、知识库、报表等有明显专属流程的任务。
+- 共用会话页：技能进入通用 Chat 页面，但必须带自己的工具条、模型限制、工具依赖和启动条件检查。
+
+```ts
+type SkillSessionMode =
+  | {
+      mode: "workspace";
+      target: "sd" | "code" | "knowledge" | "report" | string;
+    }
+  | {
+      mode: "chat";
+      toolbar: SkillSessionToolbar;
+      requiredModels?: SkillModelConfig["candidates"];
+      requiredTools?: SkillTool[];
+      requiredMcp?: SkillMcpServer[];
+    };
+```
+
+运行规则：
+
+- `launch.type = "workspace"` 时，点击技能直接进入对应工作区，不再先创建普通 Chat 会话。
+- `launch.type = "chat"` 或未声明 `launch` 时，进入共用 Chat 页面，但工具条必须由技能声明决定。
+- 启动前必须检查模型、MCP、工具和权限是否满足；不满足时进入配置页或 MCP 页，并展示明确原因。
+- 共用 Chat 只是承载壳，不代表所有技能都使用同一套按钮和参数。
+- 技能会话创建后应保存技能快照，避免市场技能更新影响历史会话行为。
+
 ### Instructions
 
 `instructions` 是技能运行时给模型的任务说明。它可以是 inline 文本，也可以引用包内文件。
@@ -352,6 +382,7 @@ type SkillRelease = {
 | `modelConfig`        | `model.default` + `model.params`               |
 | `candidateModels`    | `model.candidates`                             |
 | `plugin`             | `tools`                                        |
+| `ui.sessionToolbar`  | `ui.sessionToolbar`                            |
 | `launch.type = "sd"` | `launch = { type: "workspace", target: "sd" }` |
 | `builtin`            | `source = "builtin"`                           |
 

--- a/public/skill-packages.json
+++ b/public/skill-packages.json
@@ -46,6 +46,22 @@
             "mcp": {
                 "servers": []
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": true,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": true
+                }
+            },
             "permissions": {
                 "network": false,
                 "filesystem": false,
@@ -105,6 +121,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,
@@ -166,6 +198,22 @@
             "mcp": {
                 "servers": []
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "permissions": {
                 "network": false,
                 "filesystem": false,
@@ -225,6 +273,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,
@@ -292,6 +356,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": false,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,
@@ -363,6 +443,22 @@
             "mcp": {
                 "servers": []
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": false,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": false,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": true,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": false,
+                    "realtime": false
+                }
+            },
             "permissions": {
                 "network": false,
                 "filesystem": false,
@@ -425,6 +521,22 @@
             "mcp": {
                 "servers": []
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": true,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": true
+                }
+            },
             "permissions": {
                 "network": false,
                 "filesystem": false,
@@ -484,6 +596,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,
@@ -545,6 +673,22 @@
             "mcp": {
                 "servers": []
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "permissions": {
                 "network": false,
                 "filesystem": false,
@@ -604,6 +748,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,
@@ -671,6 +831,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": false,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,
@@ -741,6 +917,22 @@
             "tools": [],
             "mcp": {
                 "servers": []
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": false,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": false,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": true,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": false,
+                    "realtime": false
+                }
             },
             "permissions": {
                 "network": false,

--- a/public/skills.json
+++ b/public/skills.json
@@ -12,6 +12,22 @@
             ],
             "lang": "cn",
             "createdAt": 1700000001001,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": true,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": true
+                }
+            },
             "context": [
                 {
                     "id": "cn-general-0",
@@ -45,6 +61,22 @@
             ],
             "lang": "cn",
             "createdAt": 1700000001002,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "cn-web-research-0",
@@ -78,6 +110,22 @@
             ],
             "lang": "cn",
             "createdAt": 1700000001003,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "cn-reading-0",
@@ -111,6 +159,22 @@
             ],
             "lang": "cn",
             "createdAt": 1700000001004,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "cn-compare-0",
@@ -153,6 +217,22 @@
             "toolStrategy": {
                 "nativeMcpTools": "auto"
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": false,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "cn-deep-reasoning-0",
@@ -190,6 +270,22 @@
             "syncGlobalConfig": false,
             "launch": {
                 "type": "sd"
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": false,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": false,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": true,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": false,
+                    "realtime": false
+                }
             },
             "context": [
                 {
@@ -230,6 +326,22 @@
             ],
             "lang": "en",
             "createdAt": 1700000002001,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": true,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": true
+                }
+            },
             "context": [
                 {
                     "id": "en-general-0",
@@ -263,6 +375,22 @@
             ],
             "lang": "en",
             "createdAt": 1700000002002,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "en-web-research-0",
@@ -296,6 +424,22 @@
             ],
             "lang": "en",
             "createdAt": 1700000002003,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "en-reading-0",
@@ -329,6 +473,22 @@
             ],
             "lang": "en",
             "createdAt": 1700000002004,
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": true,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": true,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "en-compare-0",
@@ -371,6 +531,22 @@
             "toolStrategy": {
                 "nativeMcpTools": "auto"
             },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": true,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": true,
+                    "modelSelector": true,
+                    "imageUpload": false,
+                    "imageParams": false,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": true,
+                    "realtime": false
+                }
+            },
             "context": [
                 {
                     "id": "en-deep-reasoning-0",
@@ -408,6 +584,22 @@
             "syncGlobalConfig": false,
             "launch": {
                 "type": "sd"
+            },
+            "ui": {
+                "sessionToolbar": {
+                    "settings": false,
+                    "theme": false,
+                    "promptHints": true,
+                    "skillSwitcher": true,
+                    "clearContext": false,
+                    "modelSelector": true,
+                    "imageUpload": true,
+                    "imageParams": true,
+                    "plugins": false,
+                    "mcp": false,
+                    "shortcutKeys": false,
+                    "realtime": false
+                }
             },
             "context": [
                 {

--- a/test/sd-image-registry.test.ts
+++ b/test/sd-image-registry.test.ts
@@ -1,0 +1,32 @@
+import { resolveImageModels } from "../app/components/sd/image-registry";
+import { SupportedEndpoint } from "../app/client/api";
+import type { LLMModel } from "../app/client/api";
+
+describe("image model registry", () => {
+  test("accepts router image models marked by modelType", () => {
+    const models: LLMModel[] = [
+      {
+        name: "gpt-image-1",
+        available: true,
+        sorted: 1,
+        modelType: "image",
+        tags: [],
+        supportedEndpoints: [SupportedEndpoint.ImagesGenerations],
+        provider: {
+          id: "router",
+          providerName: "Router",
+          providerType: "router",
+          sorted: 1,
+        },
+      },
+    ];
+
+    expect(resolveImageModels(models, "generation")).toMatchObject([
+      {
+        value: "gpt-image-1",
+        providerName: "Router",
+        endpointType: "images-generation",
+      },
+    ]);
+  });
+});

--- a/test/skill-runtime.test.ts
+++ b/test/skill-runtime.test.ts
@@ -101,4 +101,31 @@ describe("skill runtime checks", () => {
     ]);
     expect(hasSkillMcpRuntimeIssue(result)).toBe(true);
   });
+
+  test("does not block SD workspace skill on chat model matching", () => {
+    const result = resolve({
+      skill: {
+        ...baseSkill,
+        id: "image",
+        name: "AI绘画",
+        launch: { type: "sd" },
+        syncGlobalConfig: false,
+        modelConfig: {
+          ...modelConfig,
+          model: "gpt-image-1",
+          providerName: ServiceProvider.OpenAI,
+        },
+        tools: {
+          builtInTools: [],
+          mcpTools: [],
+          apiTools: [],
+        },
+      },
+      models: [model],
+      installedMcpServerIds: [],
+    });
+
+    expect(result.status).toBe("ready");
+    expect(result.issues).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- add skill-specific session toolbar configuration and built-in toolbar presets
- clarify the skill session runtime model: workspace page vs shared chat page
- route image skills consistently into the SD workspace
- avoid chat runtime checks blocking SD workspace skills
- start image skills with a blank creation canvas and improve image model detection

## Tests
- npm run build
- npm run test:ci -- --runInBand test/skill-runtime.test.ts test/sd-image-registry.test.ts test/sd-image-endpoint-schema-utils.test.ts