### PR TITLE
Fix Qwen thinking on responses endpoint

### DIFF
--- a/app/client/platforms/glm.ts
+++ b/app/client/platforms/glm.ts
@@ -24,6 +24,7 @@ import {
 import { RequestPayload } from "./openai";
 import { fetch } from "@/app/utils/stream";
 import { preProcessImageContent } from "@/app/utils/chat";
+import { applyZhipuReasoning } from "../reasoning";
 
 interface BasePayload {
   model: string;
@@ -36,6 +37,9 @@ interface ChatPayload extends BasePayload {
   presence_penalty?: number;
   frequency_penalty?: number;
   top_p?: number;
+  thinking?: {
+    type: string;
+  };
 }
 
 interface ImageGenerationPayload extends BasePayload {
@@ -96,7 +100,7 @@ export class ChatGLMApi implements LLMApi {
           size: options.config.size,
         } as ImageGenerationPayload;
       default:
-        return {
+        const payload = {
           messages,
           stream: options.config.stream,
           model: modelConfig.model,
@@ -105,6 +109,11 @@ export class ChatGLMApi implements LLMApi {
           frequency_penalty: modelConfig.frequency_penalty,
           top_p: modelConfig.top_p,
         } as ChatPayload;
+        applyZhipuReasoning(payload as Record<string, any>, {
+          ...options.config,
+          ...modelConfig,
+        });
+        return payload;
     }
   }
 

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -80,10 +80,7 @@ import {
   getTimeoutMSByModel,
 } from "@/app/utils";
 import { fetch } from "@/app/utils/stream";
-import {
-  applyOpenAICompatibleReasoning,
-  applyOpenAIReasoning,
-} from "../reasoning";
+import { applyOpenAICompatibleReasoning } from "../reasoning";
 
 export interface OpenAIListModelResponse {
   object: string;
@@ -110,6 +107,10 @@ export interface RequestPayload {
   reasoning?: {
     effort: string;
   };
+  thinking?: {
+    type: string;
+  };
+  enable_thinking?: boolean;
 }
 
 export interface DalleRequestPayload {
@@ -604,6 +605,7 @@ const RESPONSES_ALLOWED_FIELDS = new Set([
   "background",
   "context_management",
   "conversation",
+  "enable_thinking",
   "include",
   "input",
   "instructions",
@@ -689,6 +691,9 @@ function toResponsesPayload(payload: Record<string, any>) {
     isReasoningModel(String(source.model ?? ""))
   ) {
     assign("reasoning", source.reasoning);
+  }
+  if (source.enable_thinking !== undefined) {
+    assign("enable_thinking", source.enable_thinking);
   }
 
   const normalizedTools = Array.isArray(source.tools) ? source.tools : [];
@@ -1088,7 +1093,7 @@ export class ChatGPTApi implements LLMApi {
             responsesPayload.temperature = modelConfig.temperature;
             responsesPayload.top_p = modelConfig.top_p;
           }
-          applyOpenAIReasoning(responsesPayload, {
+          applyOpenAICompatibleReasoning(responsesPayload, {
             ...options.config,
             model: resolvedModel,
           });

--- a/app/client/platforms/volcengine.ts
+++ b/app/client/platforms/volcengine.ts
@@ -25,6 +25,7 @@ import {
   getTimeoutMSByModel,
 } from "@/app/utils";
 import { fetch } from "@/app/utils/stream";
+import { applyVolcengineReasoning } from "../reasoning";
 
 export interface OpenAIListModelResponse {
   object: string;
@@ -47,6 +48,9 @@ interface RequestPayloadForVolcengine {
   frequency_penalty: number;
   top_p: number;
   max_tokens?: number;
+  thinking?: {
+    type: string;
+  };
 }
 
 export class VolcengineApi implements LLMApi {
@@ -115,6 +119,10 @@ export class VolcengineApi implements LLMApi {
       frequency_penalty: modelConfig.frequency_penalty,
       top_p: modelConfig.top_p,
     };
+    applyVolcengineReasoning(requestPayload as Record<string, any>, {
+      ...options.config,
+      ...modelConfig,
+    });
 
     const controller = new AbortController();
     options.onController?.(controller);

--- a/app/client/reasoning.ts
+++ b/app/client/reasoning.ts
@@ -146,6 +146,24 @@ export function applyQwenReasoning(
   parameters.enable_thinking = intent.enabled;
 }
 
+export function applyVolcengineReasoning(
+  payload: Record<string, any>,
+  config: LLMConfig,
+) {
+  const intent = resolveReasoningIntent(config);
+  if (!intent.capable) return;
+  payload.thinking = { type: intent.enabled ? "enabled" : "disabled" };
+}
+
+export function applyZhipuReasoning(
+  payload: Record<string, any>,
+  config: LLMConfig,
+) {
+  const intent = resolveReasoningIntent(config);
+  if (!intent.capable) return;
+  payload.thinking = { type: intent.enabled ? "enabled" : "disabled" };
+}
+
 export function applyOpenAICompatibleReasoning(
   payload: Record<string, any>,
   config: LLMConfig,
@@ -157,6 +175,18 @@ export function applyOpenAICompatibleReasoning(
   }
   if (provider.includes("qwen") || provider.includes("alibaba")) {
     applyQwenReasoning(payload, config);
+    return;
+  }
+  if (provider.includes("volcengine") || provider.includes("doubao")) {
+    applyVolcengineReasoning(payload, config);
+    return;
+  }
+  if (
+    provider.includes("zhipu") ||
+    provider.includes("chatglm") ||
+    provider.includes("glm")
+  ) {
+    applyZhipuReasoning(payload, config);
     return;
   }
   applyOpenAIReasoning(payload, config);


### PR DESCRIPTION
## Summary
- send Qwen-compatible reasoning controls on the /v1/responses path
- explicitly preserve enable_thinking in sanitized responses payloads
- keep plain chat behavior aligned between chat completions and responses requests

## Verification
- npx eslint app/client/platforms/openai.ts
- npm run build
