### PR TITLE
fix(auth): stabilize wallet login redirect state

### DIFF
--- a/app/components/auth.tsx
+++ b/app/components/auth.tsx
@@ -136,11 +136,13 @@ export function AuthPage() {
 
   useEffect(() => {
     let cancelled = false;
+    let refreshToken = 0;
     const refreshStatus = async () => {
+      const token = ++refreshToken;
       const account = normalizeAccount(getCurrentAccount());
       const history = mergeWalletHistory(account, loadWalletHistory());
       const valid = await isValidUcanAuthorization();
-      if (cancelled) return;
+      if (cancelled || token !== refreshToken) return;
       if (history.length > 0) {
         persistWalletHistory(history);
       }

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -391,9 +391,11 @@ function useUcanAuthState() {
 
   useEffect(() => {
     let cancelled = false;
+    let refreshToken = 0;
     const refresh = async () => {
+      const token = ++refreshToken;
       const authorized = await isValidUcanAuthorization();
-      if (cancelled) return;
+      if (cancelled || token !== refreshToken) return;
       setState({
         authorized,
         checking: false,

--- a/app/components/new-chat.tsx
+++ b/app/components/new-chat.tsx
@@ -90,6 +90,15 @@ function getSkillEntryKey(skill: Skill) {
   return skill.id || skill.name;
 }
 
+function isGeneralChatSkill(skill: Skill) {
+  return (
+    skill.name === "通用问答" ||
+    skill.name === "Direct Chat" ||
+    skill.createdAt === 1700000001001 ||
+    skill.createdAt === 1700000002001
+  );
+}
+
 export function NewChat() {
   const chatStore = useChatStore();
   const skillStore = useSkillStore();
@@ -120,6 +129,10 @@ export function NewChat() {
   );
   const currentSkillKeys = useMemo(
     () => new Set(skills.map((skill) => getSkillEntryKey(skill))),
+    [skills],
+  );
+  const defaultChatSkill = useMemo(
+    () => skills.find(isGeneralChatSkill),
     [skills],
   );
   const recentSkills = useMemo(() => {
@@ -201,6 +214,12 @@ export function NewChat() {
     const hiddenKeys = new Set(hiddenOrphanSkillKeys);
     return [...recentSkills, ...skills]
       .filter((skill) => {
+        if (
+          defaultChatSkill &&
+          getSkillEntryKey(skill) === getSkillEntryKey(defaultChatSkill)
+        ) {
+          return false;
+        }
         const key = getSkillEntryKey(skill);
         if (!key || seen.has(key)) return false;
         if (hiddenKeys.has(key)) return false;
@@ -217,7 +236,13 @@ export function NewChat() {
         return b.createdAt - a.createdAt;
       })
       .slice(0, 8);
-  }, [hiddenOrphanSkillKeys, recentSkills, skillRuntimeMap, skills]);
+  }, [
+    defaultChatSkill,
+    hiddenOrphanSkillKeys,
+    recentSkills,
+    skillRuntimeMap,
+    skills,
+  ]);
   const entrySkillItems = useMemo(
     () =>
       entrySkills.map((skill) => {
@@ -345,7 +370,8 @@ export function NewChat() {
     navigate(Path.Chat);
   };
 
-  const startDraftChat = () => startChat(undefined, draft, activeModelValue);
+  const startDraftChat = () =>
+    startChat(defaultChatSkill, draft, activeModelValue);
   const hideOrphanSkill = (skill: Skill) => {
     const key = getSkillEntryKey(skill);
     if (!key) return;
@@ -450,7 +476,7 @@ export function NewChat() {
             onClick={startDraftChat}
             type="button"
           >
-            {Locale.NewChat.BlankTitle}
+            {defaultChatSkill?.name || Locale.NewChat.BlankTitle}
             <SendWhiteIcon />
           </button>
         </div>

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -9,14 +9,15 @@ export function useAuth(options?: { notify?: boolean }) {
   const shouldNotify = options?.notify === true;
   useEffect(() => {
     let cancelled = false;
+    let checkToken = 0;
     const loginMode = (getClientConfig()?.ucanLoginForceMode || "auto")
       .trim()
       .toLowerCase();
-    const shouldNotifyWalletMissing =
-      shouldNotify && loginMode === "wallet";
+    const shouldNotifyWalletMissing = shouldNotify && loginMode === "wallet";
     const check = async () => {
+      const token = ++checkToken;
       if (localStorage.getItem("hasConnectedWallet") === "false") {
-        if (!cancelled) {
+        if (!cancelled && token === checkToken) {
           if (shouldNotifyWalletMissing) {
             notifyError("❌未检测到钱包，请先安装并连接钱包");
           }
@@ -25,7 +26,7 @@ export function useAuth(options?: { notify?: boolean }) {
         return;
       }
       const valid = await isValidUcanAuthorization();
-      if (cancelled) return;
+      if (cancelled || token !== checkToken) return;
       if (!valid) {
         setIsAuthenticated(false);
         if (shouldNotify) {

--- a/app/plugins/wallet.ts
+++ b/app/plugins/wallet.ts
@@ -6,6 +6,7 @@ import {
   releaseUcanSignLock,
 } from "./ucan-sign-lock";
 import {
+  focusPendingApproval,
   getProvider,
   requestAccounts,
   getPreferredAccount,
@@ -223,6 +224,20 @@ function clearWalletAuthState(options?: { clearAccount?: boolean }) {
   clearCachedUcanSession();
 }
 
+async function focusPendingWalletApproval(
+  provider?: Eip1193Provider | null,
+): Promise<boolean> {
+  try {
+    const providerInstance =
+      provider || (await resolveProvider({ refresh: true }));
+    if (!providerInstance) return false;
+    const result = await focusPendingApproval(providerInstance);
+    return Boolean(result?.focused);
+  } catch (error) {
+    return false;
+  }
+}
+
 function bindWalletListeners(provider: Eip1193Provider) {
   listenersCleanup?.();
   let lastObservedAccount = getCurrentAccount();
@@ -337,6 +352,9 @@ export async function connectWallet(preferredAccount?: string) {
   try {
     try {
       const provider = await requireProvider();
+      if (await focusPendingWalletApproval(provider)) {
+        return;
+      }
       const accounts = await requestAccounts({ provider, dedupe: true });
       if (Array.isArray(accounts) && accounts.length > 0) {
         const preferred = preferredAccount?.trim().toLowerCase();
@@ -481,6 +499,7 @@ export async function loginWithUcan(
     return;
   }
   if (loginInFlight) {
+    await focusPendingWalletApproval(provider || currentProvider);
     return;
   }
   loginInFlight = true;
@@ -518,7 +537,8 @@ export async function loginWithUcan(
     }
 
     if (!acquireUcanSignLock()) {
-      if (!options?.silent) {
+      const focused = await focusPendingWalletApproval(providerInstance);
+      if (!options?.silent && !focused) {
         notifyInfo("钱包签名处理中，请在钱包完成确认");
       }
       return;

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -48,7 +48,7 @@ import {
   normalizeModelCandidates,
   normalizeProviderName,
 } from "../utils/model";
-import { createEmptySkill, Skill } from "./skill";
+import { createEmptySkill, getBuiltinSkillsForLang, Skill } from "./skill";
 import { executeMcpAction, getAllTools, isMcpEnabled } from "../mcp/actions";
 import { extractMcpJson, isMcpJson } from "../mcp/utils";
 import { isValidUcanAuthorization } from "../plugins/wallet";
@@ -142,6 +142,41 @@ function createEmptySession(): ChatSession {
 
     mask: createEmptySkill(),
   };
+}
+
+function isLegacyPlainChatMaskName(name?: string) {
+  return (
+    name === "新的聊天" || name === "New Conversation" || name === DEFAULT_TOPIC
+  );
+}
+
+function getGeneralBuiltinSkill(lang = getLang()) {
+  const config = useAppConfig.getState();
+  return getBuiltinSkillsForLang(lang, config.modelConfig).find(
+    (skill) => skill.name === "通用问答" || skill.name === "Direct Chat",
+  );
+}
+
+function normalizeLegacyPlainChatSession(session: ChatSession) {
+  if (!isPlainChatSkill(session.mask)) return;
+  if (!isLegacyPlainChatMaskName(session.mask.name)) return;
+
+  const generalSkill = getGeneralBuiltinSkill(session.mask.lang || getLang());
+  if (!generalSkill) return;
+
+  const currentModelConfig = disablePlainChatReasoning(
+    session.mask.modelConfig,
+  );
+  session.mask = {
+    ...generalSkill,
+    modelConfig: currentModelConfig,
+    syncGlobalConfig:
+      session.mask.syncGlobalConfig ?? generalSkill.syncGlobalConfig,
+  };
+
+  if (isLegacyPlainChatMaskName(session.topic)) {
+    session.topic = generalSkill.name;
+  }
 }
 
 function getSummarizeModel(
@@ -1182,7 +1217,7 @@ export const useChatStore = createPersistStore(
   },
   {
     name: StoreKey.Chat,
-    version: 3.7,
+    version: 3.8,
     migrate(persistedState, version) {
       const state = persistedState as any;
       const newState = JSON.parse(
@@ -1272,11 +1307,18 @@ export const useChatStore = createPersistStore(
         });
       }
 
+      if (version < 3.8) {
+        newState.sessions.forEach((s) => {
+          normalizeLegacyPlainChatSession(s);
+        });
+      }
+
       newState.sessions.forEach((s) => {
         if (s.type !== "chat") {
           s.type = "chat";
         }
         delete (s as { studio?: unknown }).studio;
+        normalizeLegacyPlainChatSession(s);
       });
 
       return newState as any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@tauri-apps/plugin-updater": "2.9.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "@yeying-community/web3-bs": "1.0.10",
+        "@yeying-community/web3-bs": "1.0.11",
         "axios": "^1.16.1",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
@@ -6601,9 +6601,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yeying-community/web3-bs": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmmirror.com/@yeying-community/web3-bs/-/web3-bs-1.0.10.tgz",
-      "integrity": "sha512-d/siblkHug+G0UvsPTFNP8IKWWjVDgdlulW6/3y/FyLBL5kGV6A4B8lvuDnLfCwclp5D89PwsM3hq7U0Fu/MLg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmmirror.com/@yeying-community/web3-bs/-/web3-bs-1.0.11.tgz",
+      "integrity": "sha512-Tgs/1/buFDBplU5MhF+tkoXQzDsxXCYUtdEeVddRf12HT1WYPj5mSgvqbDeR8s8X0zyosq3M7VTxbfeWR44McA==",
       "license": "ISC"
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tauri-apps/plugin-updater": "2.9.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "@yeying-community/web3-bs": "1.0.10",
+    "@yeying-community/web3-bs": "1.0.11",
     "axios": "^1.16.1",
     "clsx": "^2.1.1",
     "csstype": "^3.2.3",


### PR DESCRIPTION
## Summary
- upgrade chat to web3-bs 1.0.11 and use wallet focusPendingApproval
- avoid repeated login toasts when re-focusing an existing wallet approval window
- prevent stale auth checks from overwriting fresh authorized state after wallet sign-in

## Testing
- npx eslint app/plugins/wallet.ts app/components/home.tsx app/components/auth.tsx app/hooks/useAuth.ts
- npm run build
