### PR TITLE
fix(skills): scrub legacy chat skill from storage

### DIFF
--- a/app/store/skill.ts
+++ b/app/store/skill.ts
@@ -104,6 +104,20 @@ export type SkillState = typeof DEFAULT_SKILL_STATE & {
   language?: Lang | undefined;
 };
 
+export function removeLegacySkills(skills: Record<string, Skill>) {
+  let removed = false;
+  Object.entries(skills).forEach(([id, skill]) => {
+    if (
+      LEGACY_REMOVED_SKILL_NAMES.has(skill.name) ||
+      isLegacyPlainChatSkill(skill)
+    ) {
+      delete skills[id];
+      removed = true;
+    }
+  });
+  return removed;
+}
+
 export const DEFAULT_SKILL_AVATAR = "gpt-bot";
 export const createEmptySkill = () =>
   ({
@@ -154,7 +168,6 @@ export function getBuiltinSkillsForLang(
 }
 
 export function isLaunchableSkill(skill: Skill) {
-  if (isLegacyPlainChatSkill(skill)) return false;
   if (skill.builtin) return true;
 
   return Boolean(
@@ -275,7 +288,19 @@ export const useSkillStore = createPersistStore(
   }),
   {
     name: StoreKey.Skill,
-    version: 4.3,
+    version: 4.6,
+
+    onRehydrateStorage() {
+      return (state) => {
+        if (!state?.skills) return;
+        const skills = { ...state.skills };
+        if (!removeLegacySkills(skills)) return;
+        useSkillStore.setState({
+          skills,
+          lastUpdateTime: Date.now(),
+        });
+      };
+    },
 
     migrate(state, version) {
       const legacyState = JSON.parse(JSON.stringify(state)) as SkillState & {
@@ -300,11 +325,7 @@ export const useSkillStore = createPersistStore(
       }
 
       if (version < 4.1) {
-        Object.entries(newState.skills).forEach(([id, skill]) => {
-          if (LEGACY_REMOVED_SKILL_NAMES.has(skill.name)) {
-            delete newState.skills[id];
-          }
-        });
+        removeLegacySkills(newState.skills);
       }
 
       if (version < 4.2) {
@@ -313,12 +334,8 @@ export const useSkillStore = createPersistStore(
         });
       }
 
-      if (version < 4.3) {
-        Object.entries(newState.skills).forEach(([id, skill]) => {
-          if (isLegacyPlainChatSkill(skill)) {
-            delete newState.skills[id];
-          }
-        });
+      if (version < 4.6) {
+        removeLegacySkills(newState.skills);
       }
 
       return newState as any;

--- a/app/utils/plain-chat.ts
+++ b/app/utils/plain-chat.ts
@@ -30,7 +30,20 @@ export const LEGACY_PLAIN_CHAT_SKILL_NAMES = new Set([
 ]);
 
 export function isLegacyPlainChatSkill(skill: Skill) {
+  const builtInTools = skill.tools?.builtInTools ?? [];
+
   return (
-    LEGACY_PLAIN_CHAT_SKILL_NAMES.has(skill.name) && isPlainChatSkill(skill)
+    LEGACY_PLAIN_CHAT_SKILL_NAMES.has(skill.name) &&
+    !skill.builtin &&
+    !skill.packageId &&
+    !skill.description &&
+    !skill.category &&
+    !skill.starters?.length &&
+    !skill.context?.length &&
+    !skill.plugin?.length &&
+    !skill.tools?.mcpTools?.length &&
+    !skill.tools?.apiTools?.length &&
+    !skill.launch &&
+    builtInTools.every((tool) => tool === "web_search")
   );
 }

--- a/app/utils/store.ts
+++ b/app/utils/store.ts
@@ -35,8 +35,11 @@ export function createPersistStore<T extends object, M>(
   persistOptions.storage = createJSONStorage(() => indexedDBStorage);
   const oldOonRehydrateStorage = persistOptions?.onRehydrateStorage;
   persistOptions.onRehydrateStorage = (state) => {
-    oldOonRehydrateStorage?.(state);
-    return () => state.setHasHydrated(true);
+    const oldCallback = oldOonRehydrateStorage?.(state);
+    return (hydratedState, error) => {
+      state.setHasHydrated(true);
+      oldCallback?.(hydratedState, error);
+    };
   };
 
   return create(

--- a/app/utils/sync.ts
+++ b/app/utils/sync.ts
@@ -4,7 +4,7 @@ import {
   useAppConfig,
   useChatStore,
 } from "../store";
-import { useSkillStore } from "../store/skill";
+import { removeLegacySkills, useSkillStore } from "../store/skill";
 import { usePromptStore } from "../store/prompt";
 import { StoreKey } from "../constant";
 import { merge } from "./merge";
@@ -144,6 +144,10 @@ function normalizeLegacyAppState<T extends Partial<LegacyAppState>>(state: T) {
       skills: legacySkillState.skills ?? legacySkillState.masks ?? {},
     };
   }
+  const skillState = state[StoreKey.Skill];
+  if (skillState?.skills) {
+    removeLegacySkills(skillState.skills);
+  }
   return state;
 }
 
@@ -278,6 +282,7 @@ const MergeStates: StateMerger = {
       ...(remoteSkillState.skills ?? remoteSkillState.masks ?? {}),
       ...(localSkillState.skills ?? localSkillState.masks ?? {}),
     };
+    removeLegacySkills(localState.skills);
     return localState;
   },
   [StoreKey.Config]: (localState, remoteState) =>

--- a/test/plain-chat.test.ts
+++ b/test/plain-chat.test.ts
@@ -60,6 +60,19 @@ describe("plain chat reasoning isolation", () => {
     expect(isLegacyPlainChatSkill(plainSkill)).toBe(true);
   });
 
+  test("detects legacy chat skill with old web search tool", () => {
+    expect(
+      isLegacyPlainChatSkill({
+        ...plainSkill,
+        tools: {
+          builtInTools: ["web_search"],
+          mcpTools: [],
+          apiTools: [],
+        },
+      }),
+    ).toBe(true);
+  });
+
   test("does not treat prompted skill as ordinary chat", () => {
     expect(
       isPlainChatSkill({
@@ -76,15 +89,16 @@ describe("plain chat reasoning isolation", () => {
     ).toBe(false);
   });
 
-  test("does not treat built-in general chat as legacy plain chat", () => {
-    const generalSkill = {
-      ...plainSkill,
-      id: "general",
-      name: "通用问答",
-      builtin: true,
-      description: "日常问答、写作、分析和轻量任务处理。",
-    } as Skill;
-
-    expect(isLegacyPlainChatSkill(generalSkill)).toBe(false);
+  test("does not treat installed general chat as legacy chat", () => {
+    expect(
+      isLegacyPlainChatSkill({
+        ...plainSkill,
+        id: "general",
+        name: "通用问答",
+        packageId: "builtin.cn.1700000001001",
+        category: "基础",
+        description: "日常问答、写作、分析和轻量任务处理。",
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- clean legacy default chat skill records from the skill store baseline
- preserve page semantics by keeping cleanup in storage migration/hydration/sync paths
- keep persisted store hydration callbacks composable

## Tests
- npm run test:ci -- --runTestsByPath test/plain-chat.test.ts
- npm run build