### PR TITLE
feat(sd): drive image params from model spec

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -103,6 +103,28 @@ export interface LLMConfig {
   style?: DalleRequestPayload["style"];
 }
 
+export interface ModelParameterSpecification {
+  type?: string;
+  allowed_values?: string[];
+  min?: number;
+  max?: number;
+}
+
+export interface ModelEndpointSpecification {
+  input_modalities?: string[];
+  output_modalities?: string[];
+  parameters?: Record<string, ModelParameterSpecification>;
+  constraints?: {
+    min_pixels?: number;
+    allowed_aspect_ratios?: string[];
+  };
+}
+
+export interface ModelSpecification {
+  version?: number;
+  endpoints?: Record<string, ModelEndpointSpecification>;
+}
+
 export interface SpeechOptions {
   model: string;
   input: string;
@@ -142,6 +164,7 @@ export interface LLMModel {
   status?: string;
   description?: string;
   isDefault?: boolean;
+  specification?: ModelSpecification;
 }
 
 export interface ModelCandidate {

--- a/app/client/platforms/router.ts
+++ b/app/client/platforms/router.ts
@@ -51,6 +51,7 @@ type RouterModelCard = {
   id?: string;
   owned_by?: string;
   tags?: string[];
+  specification?: LLMModel["specification"];
   supported_endpoints?: string[];
 };
 
@@ -65,6 +66,7 @@ type RouterProviderModelDetail = {
   status?: string;
   description?: string;
   tags?: string[];
+  specification?: LLMModel["specification"];
   supported_endpoints?: string[];
 };
 
@@ -442,6 +444,7 @@ function buildModelsFromProviderModels(
         modelType: detail.type?.trim() || undefined,
         status: detail.status?.trim() || undefined,
         description: detail.description?.trim() || undefined,
+        specification: detail.specification,
         provider: {
           id: providerID,
           providerName,
@@ -590,6 +593,7 @@ export class RouterApi implements LLMApi {
           sorted: seq++,
           ownedBy: (item.owned_by || "").trim() || undefined,
           tags: normalizeTags(item.tags),
+          specification: item.specification,
           supportedEndpoints,
           provider: {
             id: providerId(providerName),

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -7,7 +7,7 @@ import clsx from "clsx";
 export type ButtonType = "primary" | "danger" | null;
 
 export function IconButton(props: {
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   icon?: React.ReactNode;
   type?: ButtonType;
   text?: string;

--- a/app/components/discovery.module.scss
+++ b/app/components/discovery.module.scss
@@ -73,6 +73,20 @@
   box-sizing: border-box;
 }
 
+.card-clickable {
+  cursor: pointer;
+  transition:
+    border-color ease 0.2s,
+    box-shadow ease 0.2s,
+    transform ease 0.2s;
+
+  &:hover {
+    border-color: var(--primary);
+    box-shadow: var(--card-shadow);
+    transform: translateY(-1px);
+  }
+}
+
 .card-header {
   display: flex;
   justify-content: space-between;

--- a/app/components/discovery.tsx
+++ b/app/components/discovery.tsx
@@ -821,6 +821,11 @@ export function DiscoveryPage() {
           const statuses = await getClientsStatus();
           setMcpConfig(newConfig);
           setMcpStatuses(statuses);
+          setViewingMcpCapability({
+            ...item,
+            installed: true,
+            status: Locale.Discovery.Status.Installed,
+          });
           showToast(Locale.Discovery.Status.Enabled);
         } catch (error) {
           showToast(
@@ -970,7 +975,26 @@ export function DiscoveryPage() {
 
           <div className={styles.grid}>
             {visibleCapabilities.map((item) => (
-              <div key={item.id} className={styles.card}>
+              <div
+                key={item.id}
+                className={clsx(
+                  styles.card,
+                  item.type === "mcp" && styles["card-clickable"],
+                )}
+                role={item.type === "mcp" ? "button" : undefined}
+                tabIndex={item.type === "mcp" ? 0 : undefined}
+                onClick={() => {
+                  if (item.type === "mcp") {
+                    setViewingMcpCapability(item);
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (item.type !== "mcp") return;
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  setViewingMcpCapability(item);
+                }}
+              >
                 <div className={styles["card-header"]}>
                   <div className={styles["card-title"]}>
                     <span className={styles["type-icon"]} aria-hidden>
@@ -1004,14 +1028,20 @@ export function DiscoveryPage() {
                     icon={<EyeIcon />}
                     text={getActionText(item)}
                     bordered
-                    onClick={() => handleCapabilityAction(item)}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleCapabilityAction(item);
+                    }}
                   />
                   {item.type === "skill" && item.skill && (
                     <IconButton
                       icon={<EditIcon />}
                       text={Locale.Discovery.Configure}
                       bordered
-                      onClick={() => openSkillConfig(item.skill!)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        openSkillConfig(item.skill!);
+                      }}
                     />
                   )}
                 </div>

--- a/app/components/sd/image-endpoint-schema-utils.ts
+++ b/app/components/sd/image-endpoint-schema-utils.ts
@@ -1,21 +1,6 @@
 import type { ImageEndpointSchema } from "./image-endpoint-schemas";
-
-function isGptImageModel(model: string) {
-  return model.toLowerCase().startsWith("gpt-image");
-}
-
-function getDefaultQuality(model: string) {
-  return isGptImageModel(model) ? "auto" : "standard";
-}
-
-function resolveImageQuality(model: string, quality?: string) {
-  const values = isGptImageModel(model)
-    ? ["auto", "low", "medium", "high"]
-    : ["standard", "hd"];
-  return quality && values.includes(quality)
-    ? quality
-    : getDefaultQuality(model);
-}
+import type { ModelSpecification } from "@/app/client/api";
+import { normalizeImageParamsForModel } from "./image-param-spec";
 
 export type ResolvedImageResult = NonNullable<
   ReturnType<ImageEndpointSchema["resolveImageResult"]>
@@ -24,15 +9,23 @@ export type ResolvedImageResult = NonNullable<
 export function buildOpenAIImageEditFormData(data: {
   model: string;
   params: Record<string, any>;
+  specification?: ModelSpecification;
   sourceImage?: Blob;
   maskImage?: Blob;
 }) {
   const body = new FormData();
+  const normalizedParams = normalizeImageParamsForModel({
+    model: data.model,
+    endpointType: "images-edits",
+    specification: data.specification,
+    params: data.params,
+  });
   body.append("model", data.model);
   body.append("prompt", data.params.prompt || "");
-  body.append("size", data.params.size || "1024x1024");
-  body.append("quality", resolveImageQuality(data.model, data.params.quality));
   body.append("style", data.params.style || "vivid");
+  Object.entries(normalizedParams).forEach(([key, value]) => {
+    body.append(key, String(value));
+  });
   if (data.sourceImage) {
     body.append("image", data.sourceImage, "image.png");
   }

--- a/app/components/sd/image-endpoint-schemas.ts
+++ b/app/components/sd/image-endpoint-schemas.ts
@@ -1,48 +1,13 @@
 import Locale from "@/app/locales";
+import type { ModelSpecification } from "@/app/client/api";
 import {
   buildOpenAIImageEditFormData,
   resolveOpenAIImageResult,
 } from "./image-endpoint-schema-utils";
-
-function isGptImageModel(model?: string) {
-  return model?.toLowerCase().startsWith("gpt-image") ?? false;
-}
-
-function resolveImageQuality(model: string, quality?: string) {
-  const values = isGptImageModel(model)
-    ? ["auto", "low", "medium", "high"]
-    : ["standard", "hd"];
-  const defaultQuality = isGptImageModel(model) ? "auto" : "standard";
-  return quality && values.includes(quality) ? quality : defaultQuality;
-}
-
-function getImageQualityParam(model?: string): ImageParamSchema {
-  if (isGptImageModel(model)) {
-    return {
-      name: Locale.SdPanel.ImageQuality,
-      value: "quality",
-      type: "select",
-      default: "auto",
-      options: [
-        { name: "auto", value: "auto" },
-        { name: "high", value: "high" },
-        { name: "medium", value: "medium" },
-        { name: "low", value: "low" },
-      ],
-    };
-  }
-
-  return {
-    name: Locale.SdPanel.ImageQuality,
-    value: "quality",
-    type: "select",
-    default: "standard",
-    options: [
-      { name: "standard", value: "standard" },
-      { name: "hd", value: "hd" },
-    ],
-  };
-}
+import {
+  buildImageModelParamSchemas,
+  normalizeImageParamsForModel,
+} from "./image-param-spec";
 
 export type ImageEndpointType = "images-generation" | "images-edits";
 export type ImageFormMode = "generation" | "editing";
@@ -70,6 +35,7 @@ export type ImageEndpointSchema = {
   buildRequestBody: (data: {
     model: string;
     params: Record<string, any>;
+    specification?: ModelSpecification;
     sourceImage?: Blob;
     maskImage?: Blob;
   }) => Record<string, any> | FormData;
@@ -94,17 +60,27 @@ const promptParam: ImageParamSchema = {
   required: true,
 };
 
-const imageSizeParam: ImageParamSchema = {
-  name: Locale.SdPanel.ImageSize,
-  value: "size",
-  type: "select",
-  default: "1024x1024",
-  options: [
-    { name: "1024x1024", value: "1024x1024" },
-    { name: "1792x1024", value: "1792x1024" },
-    { name: "1024x1792", value: "1024x1792" },
-  ],
-};
+function getModelParams(
+  model: string | undefined,
+  endpointType: ImageEndpointType,
+  specification?: ModelSpecification,
+) {
+  return buildImageModelParamSchemas({ model, endpointType, specification });
+}
+
+function normalizeRequestParams(
+  model: string,
+  endpointType: ImageEndpointType,
+  specification: ModelSpecification | undefined,
+  params: Record<string, any>,
+) {
+  return normalizeImageParamsForModel({
+    model,
+    endpointType,
+    specification,
+    params,
+  });
+}
 
 const imageStyleParam: ImageParamSchema = {
   name: Locale.SdPanel.ImageStyle,
@@ -122,21 +98,32 @@ export const imageEndpointSchemas: Record<
   ImageEndpointSchema
 > = {
   "images-generation": {
-    params: (data) => [
-      promptParam,
-      imageSizeParam,
-      getImageQualityParam(data?.model),
-      imageStyleParam,
-    ],
-    buildRequestBody: ({ model, params }) => ({
-      model,
-      prompt: params.prompt,
-      response_format: "b64_json",
-      n: 1,
-      size: params.size || "1024x1024",
-      quality: resolveImageQuality(model, params.quality),
-      style: params.style || "vivid",
-    }),
+    params: (data) =>
+      [
+        promptParam,
+        ...getModelParams(
+          data?.model,
+          "images-generation",
+          data?.specification,
+        ),
+        imageStyleParam,
+      ].filter(Boolean) as ImageParamSchema[],
+    buildRequestBody: ({ model, params, specification }) => {
+      const normalizedParams = normalizeRequestParams(
+        model,
+        "images-generation",
+        specification,
+        params,
+      );
+      return {
+        model,
+        prompt: params.prompt,
+        response_format: "b64_json",
+        n: normalizedParams.n ?? 1,
+        ...normalizedParams,
+        style: params.style || "vivid",
+      };
+    },
     resolveImageResult: resolveOpenAIImageResult,
     resolveErrorMessage: (response) =>
       response?.error?.message ||
@@ -145,12 +132,12 @@ export const imageEndpointSchemas: Record<
       "",
   },
   "images-edits": {
-    params: (data) => [
-      promptParam,
-      imageSizeParam,
-      getImageQualityParam(data?.model),
-      imageStyleParam,
-    ],
+    params: (data) =>
+      [
+        promptParam,
+        ...getModelParams(data?.model, "images-edits", data?.specification),
+        imageStyleParam,
+      ].filter(Boolean) as ImageParamSchema[],
     buildRequestBody: buildOpenAIImageEditFormData,
     resolveImageResult: resolveOpenAIImageResult,
     resolveErrorMessage: (response) =>

--- a/app/components/sd/image-param-display.ts
+++ b/app/components/sd/image-param-display.ts
@@ -10,9 +10,16 @@ export function getParamLabel(value: string) {
     case "aspect_ratio":
       return Locale.SdPanel.AspectRatio;
     case "size":
+    case "image_size":
       return Locale.SdPanel.ImageSize;
+    case "width":
+      return "Width";
+    case "height":
+      return "Height";
     case "quality":
       return Locale.SdPanel.ImageQuality;
+    case "n":
+      return "N";
     case "style":
       return Locale.SdPanel.ImageStyle;
     case "seed":

--- a/app/components/sd/image-param-spec.ts
+++ b/app/components/sd/image-param-spec.ts
@@ -1,0 +1,192 @@
+import type {
+  ModelEndpointSpecification,
+  ModelParameterSpecification,
+  ModelSpecification,
+} from "@/app/client/api";
+import Locale from "@/app/locales";
+import type {
+  ImageEndpointType,
+  ImageParamSchema,
+} from "./image-endpoint-schemas";
+
+const IMAGE_ENDPOINT_PATHS: Record<ImageEndpointType, string> = {
+  "images-generation": "/v1/images/generations",
+  "images-edits": "/v1/images/edits",
+};
+
+const DEFAULT_SIZE_OPTIONS = [
+  { name: "1024x1024", value: "1024x1024" },
+  { name: "1792x1024", value: "1792x1024" },
+  { name: "1024x1792", value: "1024x1792" },
+];
+
+const DEFAULT_DALLE_QUALITY_OPTIONS = [
+  { name: "standard", value: "standard" },
+  { name: "hd", value: "hd" },
+];
+
+const DEFAULT_GPT_IMAGE_QUALITY_OPTIONS = [
+  { name: "auto", value: "auto" },
+  { name: "high", value: "high" },
+  { name: "medium", value: "medium" },
+  { name: "low", value: "low" },
+];
+
+const SPEC_PARAM_ORDER = [
+  "size",
+  "image_size",
+  "aspect_ratio",
+  "width",
+  "height",
+  "quality",
+  "n",
+];
+
+function isGptImageModel(model?: string) {
+  return model?.toLowerCase().startsWith("gpt-image") ?? false;
+}
+
+function endpointSpec(
+  specification: ModelSpecification | undefined,
+  endpointType: ImageEndpointType,
+): ModelEndpointSpecification | undefined {
+  return specification?.endpoints?.[IMAGE_ENDPOINT_PATHS[endpointType]];
+}
+
+function valuesToOptions(values?: string[]) {
+  return (values ?? [])
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => ({ name: value, value }));
+}
+
+function enumParam(
+  name: string,
+  value: string,
+  parameter?: ModelParameterSpecification,
+): ImageParamSchema | undefined {
+  const options = valuesToOptions(parameter?.allowed_values);
+  if (options.length === 0) return undefined;
+  return {
+    name,
+    value,
+    type: "select",
+    default: options[0].value,
+    options,
+  };
+}
+
+function numberParam(
+  name: string,
+  value: string,
+  parameter?: ModelParameterSpecification,
+): ImageParamSchema | undefined {
+  if (!parameter) return undefined;
+  return {
+    name,
+    value,
+    type: "number",
+    default: parameter.min ?? 1,
+    min: parameter.min,
+    max: parameter.max,
+  };
+}
+
+function defaultSizeParam(): ImageParamSchema {
+  return {
+    name: Locale.SdPanel.ImageSize,
+    value: "size",
+    type: "select",
+    default: DEFAULT_SIZE_OPTIONS[0].value,
+    options: DEFAULT_SIZE_OPTIONS,
+  };
+}
+
+function defaultQualityParam(model?: string): ImageParamSchema {
+  const options = isGptImageModel(model)
+    ? DEFAULT_GPT_IMAGE_QUALITY_OPTIONS
+    : DEFAULT_DALLE_QUALITY_OPTIONS;
+  return {
+    name: Locale.SdPanel.ImageQuality,
+    value: "quality",
+    type: "select",
+    default: options[0].value,
+    options,
+  };
+}
+
+function buildSpecParam(
+  key: string,
+  parameter: ModelParameterSpecification | undefined,
+): ImageParamSchema | undefined {
+  switch (key) {
+    case "size":
+      return enumParam(Locale.SdPanel.ImageSize, key, parameter);
+    case "image_size":
+      return enumParam(Locale.SdPanel.ImageSize, key, parameter);
+    case "aspect_ratio":
+      return enumParam(Locale.SdPanel.AspectRatio, key, parameter);
+    case "quality":
+      return enumParam(Locale.SdPanel.ImageQuality, key, parameter);
+    case "width":
+      return numberParam("Width", key, parameter);
+    case "height":
+      return numberParam("Height", key, parameter);
+    case "n":
+      return numberParam("N", key, parameter);
+    default:
+      return undefined;
+  }
+}
+
+export function buildImageModelParamSchemas(input: {
+  model?: string;
+  endpointType: ImageEndpointType;
+  specification?: ModelSpecification;
+}): ImageParamSchema[] {
+  const spec = endpointSpec(input.specification, input.endpointType);
+  const parameters = spec?.parameters ?? {};
+  const schemas = SPEC_PARAM_ORDER.map((key) =>
+    buildSpecParam(key, parameters[key]),
+  ).filter(Boolean) as ImageParamSchema[];
+
+  if (schemas.length > 0) return schemas;
+
+  return [defaultSizeParam(), defaultQualityParam(input.model)];
+}
+
+function normalizeBySchema(schema: ImageParamSchema, raw: any) {
+  if (schema.type === "select") {
+    const values = schema.options?.map((option) => option.value) ?? [];
+    return values.includes(raw) ? raw : schema.default || values[0] || "";
+  }
+
+  if (schema.type === "number") {
+    const fallback = schema.default ?? schema.min ?? 0;
+    const value = Number(raw ?? fallback);
+    const finiteValue = Number.isFinite(value) ? value : fallback;
+    const min = typeof schema.min === "number" ? schema.min : undefined;
+    const max = typeof schema.max === "number" ? schema.max : undefined;
+    if (typeof min === "number" && finiteValue < min) return min;
+    if (typeof max === "number" && finiteValue > max) return max;
+    return finiteValue;
+  }
+
+  return raw ?? schema.default ?? "";
+}
+
+export function normalizeImageParamsForModel(input: {
+  model?: string;
+  endpointType: ImageEndpointType;
+  specification?: ModelSpecification;
+  params?: Record<string, any>;
+}) {
+  const schemas = buildImageModelParamSchemas(input);
+  return schemas.reduce<Record<string, any>>((next, schema) => {
+    next[schema.value] = normalizeBySchema(
+      schema,
+      input.params?.[schema.value],
+    );
+    return next;
+  }, {});
+}

--- a/app/components/sd/image-registry.ts
+++ b/app/components/sd/image-registry.ts
@@ -17,6 +17,7 @@ export type ImageModelDefinition = {
   providerName: string;
   endpointType: ImageEndpointType;
   supportsImage: true;
+  specification?: LLMModel["specification"];
   params: (data: any) => ImageParamSchema[];
 };
 
@@ -70,10 +71,12 @@ function buildRuntimeImageModelForMode(
     providerName,
     endpointType,
     supportsImage: true,
+    specification: model.specification,
     params: (data: any) =>
       getImageEndpointSchema(endpointType).params({
         ...data,
         model: model.name,
+        specification: model.specification,
       }),
   };
 }

--- a/app/components/sd/sd-panel.tsx
+++ b/app/components/sd/sd-panel.tsx
@@ -639,11 +639,20 @@ export function ControlParam(props: {
     >
       {props.columns?.map((item) => {
         let element: null | React.ReactNode;
-        const compactSelectRowFields = ["size", "quality", "style"];
+        const compactSelectRowFields = [
+          "size",
+          "image_size",
+          "aspect_ratio",
+          "width",
+          "height",
+          "quality",
+          "n",
+          "style",
+        ];
         const compactSelectIndex = compactSelectRowFields.indexOf(item.value);
         const hideCompactTitle =
           props.compact &&
-          item.type === "select" &&
+          (item.type === "select" || item.type === "number") &&
           compactSelectRowFields.includes(item.value);
         const compactItemClass = props.compact
           ? item.type === "textarea"
@@ -768,6 +777,23 @@ export const getModelParamBasicData = (
   columns.forEach((item: any) => {
     if (clearText && ["text", "textarea", "number"].includes(item.type)) {
       newParams[item.value] = item.default || "";
+    } else if (item.type === "select" && Array.isArray(item.options)) {
+      const currentValue = data[item.value];
+      const optionValues = item.options.map((option: any) => option.value);
+      newParams[item.value] = optionValues.includes(currentValue)
+        ? currentValue
+        : item.default || optionValues[0] || "";
+    } else if (item.type === "number") {
+      const fallback = item.default ?? item.min ?? "";
+      const currentValue = Number(data[item.value] ?? fallback);
+      const nextValue = Number.isFinite(currentValue) ? currentValue : fallback;
+      if (typeof item.min === "number" && nextValue < item.min) {
+        newParams[item.value] = item.min;
+      } else if (typeof item.max === "number" && nextValue > item.max) {
+        newParams[item.value] = item.max;
+      } else {
+        newParams[item.value] = nextValue;
+      }
     } else {
       // @ts-ignore
       newParams[item.value] = data[item.value] || item.default || "";
@@ -808,7 +834,16 @@ export function SdPanel() {
     [currentModel, params],
   );
   const orderedModelParams = React.useMemo(() => {
-    const selectorFields = ["size", "quality", "style"];
+    const selectorFields = [
+      "size",
+      "image_size",
+      "aspect_ratio",
+      "width",
+      "height",
+      "quality",
+      "n",
+      "style",
+    ];
     const selectors = selectorFields
       .map((field) => modelParams.find((item) => item.value === field))
       .filter(Boolean);
@@ -829,6 +864,7 @@ export function SdPanel() {
     );
     if (matched && matched !== currentModel) {
       setCurrentModel(matched);
+      setParams(getModelParamBasicData(matched.params(params), params));
       return;
     }
     if (!matched) {

--- a/app/components/sd/sd-sidebar.tsx
+++ b/app/components/sd/sd-sidebar.tsx
@@ -72,6 +72,7 @@ export function SideBar(props: { className?: string }) {
       provider: currentModel.provider || "",
       provider_name: currentModel.providerName || "",
       endpoint_type: currentModel.endpointType || "",
+      specification: currentModel.specification,
       session_id: currentSessionId,
       model_def: currentModel,
       model: currentModel.value,

--- a/app/components/sd/sd.tsx
+++ b/app/components/sd/sd.tsx
@@ -228,8 +228,9 @@ export function Sd() {
                             </button>
                             <div className={styles["sd-img-sub-meta"]}>
                               <span>{item.created_at}</span>
-                              <span>{item.model_name}</span>
-                              <span>{item.provider_name}</span>
+                              <span title={item.provider_name}>
+                                {item.model_name}
+                              </span>
                             </div>
                           </div>
                           {getSdTaskStatus(item)}
@@ -290,6 +291,7 @@ export function Sd() {
                                 provider: item.provider,
                                 provider_name: item.provider_name,
                                 endpoint_type: item.endpoint_type,
+                                specification: item.specification,
                                 session_id:
                                   item.session_id || activeSessionId || "",
                                 model_def: item.model_def,

--- a/app/store/sd.ts
+++ b/app/store/sd.ts
@@ -188,6 +188,7 @@ export const useSdStore = createPersistStore<
         const requestBody = schema.buildRequestBody({
           model: data.model,
           params: data.params,
+          specification: data.specification,
           sourceImage,
           maskImage,
         });
@@ -321,7 +322,9 @@ export const useSdStore = createPersistStore<
         const currentModel = _get().currentModel;
         const sessionId = nanoid();
         const currentParams = getModelParamBasicData(
-          currentModel?.params?.({}) ?? [],
+          currentModel?.params?.({
+            specification: currentModel?.specification,
+          }) ?? [],
           {},
         );
         set({


### PR DESCRIPTION
## Summary
- Preserve router model specification metadata in Chat model records
- Drive AI drawing parameters from image model specification, including size, image_size, aspect_ratio, width/height, quality, and n
- Improve MCP discovery card interactions and reduce AI drawing card metadata density

## Test
- npm run build