### PR TITLE
fix: scope router models by selected token

### DIFF
--- a/app/components/router-model-catalog.ts
+++ b/app/components/router-model-catalog.ts
@@ -1,0 +1,65 @@
+import type { LLMModel } from "../client/api";
+
+function providerKeys(model: LLMModel) {
+  return [model.provider?.id, model.provider?.providerName, model.ownedBy]
+    .map((value) => value?.trim().toLowerCase())
+    .filter(Boolean) as string[];
+}
+
+function buildMetadataIndex(providerModels: readonly LLMModel[]) {
+  const byExactKey = new Map<string, LLMModel>();
+  const byName = new Map<string, LLMModel[]>();
+
+  providerModels.forEach((model) => {
+    const name = model.name.trim().toLowerCase();
+    if (!name) return;
+
+    providerKeys(model).forEach((providerKey) => {
+      byExactKey.set(`${name}@${providerKey}`, model);
+    });
+
+    const models = byName.get(name) ?? [];
+    models.push(model);
+    byName.set(name, models);
+  });
+
+  return { byExactKey, byName };
+}
+
+function findMetadata(
+  model: LLMModel,
+  index: ReturnType<typeof buildMetadataIndex>,
+) {
+  const name = model.name.trim().toLowerCase();
+  if (!name) return undefined;
+
+  for (const providerKey of providerKeys(model)) {
+    const matched = index.byExactKey.get(`${name}@${providerKey}`);
+    if (matched) return matched;
+  }
+
+  const byName = index.byName.get(name) ?? [];
+  return byName.length === 1 ? byName[0] : undefined;
+}
+
+export function buildTokenScopedRouterModelCatalog(
+  tokenModels: readonly LLMModel[],
+  providerModels: readonly LLMModel[],
+) {
+  const index = buildMetadataIndex(providerModels);
+
+  return tokenModels.map((model) => {
+    const metadata = findMetadata(model, index);
+    if (!metadata) return model;
+
+    return {
+      ...model,
+      displayName: model.displayName || metadata.displayName,
+      tags: model.tags?.length ? model.tags : metadata.tags,
+      modelType: model.modelType || metadata.modelType,
+      status: model.status || metadata.status,
+      description: model.description || metadata.description,
+      specification: model.specification || metadata.specification,
+    };
+  });
+}

--- a/app/components/router-page.tsx
+++ b/app/components/router-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import styles from "./router-page.module.scss";
 
@@ -32,6 +32,7 @@ import {
   type RouterPublicToken,
   type RouterTokenStatus,
 } from "../client/platforms/router";
+import { buildTokenScopedRouterModelCatalog } from "./router-model-catalog";
 
 const normalizeUrl = (value: string) => value.replace(/\/+$/, "");
 const ROUTER_BASE_URL =
@@ -142,7 +143,6 @@ function isRouterTokenSelectable(token: RouterPublicToken) {
 
 export function RouterPage() {
   const navigate = useNavigate();
-  const config = useAppConfig();
   const mergeModels = useAppConfig((state) => state.mergeModels);
   const accessStore = useAccessStore();
   const updateStore = useUpdateStore();
@@ -157,18 +157,18 @@ export function RouterPage() {
   const [searchText, setSearchText] = useState("");
   const [filter, setFilter] = useState<ModelFilter>("all");
   const [tokens, setTokens] = useState<RouterPublicToken[]>([]);
+  const [tokenModels, setTokenModels] = useState<LLMModel[]>([]);
   const [tokenStatus, setTokenStatus] = useState<RouterTokenStatus | null>(
     null,
   );
 
-  const runtimeModels = useMemo(
-    () => config.models.filter((model) => model.available),
-    [config.models],
-  );
-
   const catalogModels = useMemo(() => {
-    const source = providerModels.length > 0 ? providerModels : runtimeModels;
     const map = new Map<string, LLMModel>();
+    const source = buildTokenScopedRouterModelCatalog(
+      tokenModels,
+      providerModels,
+    );
+
     source.forEach((model) => {
       const providerId =
         model.provider?.id ||
@@ -178,7 +178,7 @@ export function RouterPage() {
       map.set(`${model.name}@${providerId}`, model);
     });
     return Array.from(map.values());
-  }, [providerModels, runtimeModels]);
+  }, [providerModels, tokenModels]);
 
   const visibleModels = useMemo(() => {
     const keyword = searchText.trim().toLowerCase();
@@ -259,20 +259,22 @@ export function RouterPage() {
     }
   }
 
-  async function reloadModels() {
+  const reloadModels = useCallback(async () => {
     setLoadingModels(true);
+    setTokenModels([]);
     try {
       const api = getRouterClientApi();
       const [models, nextProviderModels] = await Promise.all([
         api.llm.models(),
         api.llm.providerModels?.() ?? Promise.resolve([]),
       ]);
+      setTokenModels(models);
       mergeModels(models);
       setProviderModels(nextProviderModels);
     } finally {
       setLoadingModels(false);
     }
-  }
+  }, [mergeModels, setProviderModels]);
 
   async function loadTokens() {
     setLoadingTokens(true);
@@ -301,6 +303,14 @@ export function RouterPage() {
   useEffect(() => {
     void loadTokenStatus();
   }, [selectedRouterToken]);
+
+  useEffect(() => {
+    if (!selectedRouterToken) {
+      setTokenModels([]);
+      return;
+    }
+    void reloadModels();
+  }, [reloadModels, selectedRouterToken]);
 
   return (
     <ErrorBoundary>
@@ -545,7 +555,7 @@ export function RouterPage() {
               <div>
                 <div className={styles["panel-title"]}>支持模型</div>
                 <div className={styles["panel-subtitle"]}>
-                  Router 当前返回的模型目录。
+                  当前令牌可用的模型。
                 </div>
               </div>
             </div>
@@ -653,7 +663,13 @@ export function RouterPage() {
                 </table>
               </div>
             ) : (
-              <div className={styles.empty}>没有匹配到模型</div>
+              <div className={styles.empty}>
+                {loadingModels
+                  ? "模型加载中"
+                  : selectedRouterToken
+                    ? "当前令牌没有返回可用模型"
+                    : "请选择令牌后加载模型"}
+              </div>
             )}
           </section>
         </div>

--- a/test/router-model-catalog.test.ts
+++ b/test/router-model-catalog.test.ts
@@ -1,0 +1,60 @@
+import { buildTokenScopedRouterModelCatalog } from "../app/components/router-model-catalog";
+import { ServiceProvider } from "../app/constant";
+import type { LLMModel } from "../app/client/api";
+
+function model(name: string, providerName: ServiceProvider, extra = {}) {
+  return {
+    name,
+    available: true,
+    sorted: 1,
+    provider: {
+      id: providerName.toLowerCase(),
+      providerName,
+      providerType: providerName.toLowerCase(),
+      sorted: 1,
+    },
+    ...extra,
+  } as LLMModel;
+}
+
+describe("buildTokenScopedRouterModelCatalog", () => {
+  test("does not expand token-scoped models with provider catalog models", () => {
+    const tokenModels = [model("qwen-plus", ServiceProvider.Alibaba)];
+    const providerModels = [
+      model("qwen-plus", ServiceProvider.Alibaba, {
+        tags: ["reasoning"],
+        description: "Qwen Plus",
+      }),
+      model("gpt-4.1", ServiceProvider.OpenAI),
+    ];
+
+    const catalog = buildTokenScopedRouterModelCatalog(
+      tokenModels,
+      providerModels,
+    );
+
+    expect(catalog.map((item) => item.name)).toEqual(["qwen-plus"]);
+    expect(catalog[0].tags).toEqual(["reasoning"]);
+    expect(catalog[0].description).toBe("Qwen Plus");
+  });
+
+  test("does not merge ambiguous same-name provider metadata", () => {
+    const tokenModels = [model("shared-model", ServiceProvider.OpenAI)];
+    const providerModels = [
+      model("shared-model", ServiceProvider.Alibaba, {
+        tags: ["qwen"],
+      }),
+      model("shared-model", ServiceProvider.Google, {
+        tags: ["gemini"],
+      }),
+    ];
+
+    const catalog = buildTokenScopedRouterModelCatalog(
+      tokenModels,
+      providerModels,
+    );
+
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0].tags).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- show only token-scoped `/v1/models` results on the Router page
- use provider catalog data only as metadata enrichment for the visible token model list
- reload the Router model list when the selected token changes and improve empty/loading states

## Tests
- npm test -- --watch=false --runInBand test/router-model-catalog.test.ts test/model-provider.test.ts test/model-available.test.ts
- npx eslint app/components/router-page.tsx app/components/router-model-catalog.ts test/router-model-catalog.test.ts