### PR TITLE
feat: isolate browser workspace by account

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 require("../polyfill");
+import "../utils/account-workspace";
 
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import styles from "./home.module.scss";

--- a/app/components/storage-page.module.scss
+++ b/app/components/storage-page.module.scss
@@ -75,6 +75,12 @@
   opacity: 0.72;
 }
 
+.status-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--primary);
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;

--- a/app/components/storage-page.tsx
+++ b/app/components/storage-page.tsx
@@ -10,6 +10,7 @@ import ResetIcon from "../icons/reload.svg";
 import LoadingIcon from "../icons/three-dots.svg";
 import UploadIcon from "../icons/upload.svg";
 import Locale from "../locales";
+import { getCurrentAccount } from "../plugins/wallet";
 import { fetchQuota, WebDAVQuota } from "../plugins/webdav";
 import { useChatStore } from "../store";
 import { usePromptStore } from "../store/prompt";
@@ -20,6 +21,7 @@ import {
 } from "../store/skill";
 import { useSyncStore } from "../store/sync";
 import { ProviderType } from "../utils/cloud";
+import { getAccountWorkspaceSyncDelayMs } from "../utils/account-workspace";
 import { formatBytes } from "../utils/format";
 import { IconButton } from "./button";
 import { ErrorBoundary } from "./error";
@@ -65,6 +67,7 @@ export function StoragePage() {
   const [quotaState, setQuotaState] = useState<QuotaState>("idle");
   const [checkState, setCheckState] = useState<CheckState>("none");
   const [syncing, setSyncing] = useState(false);
+  const [workspaceSyncDelayMs, setWorkspaceSyncDelayMs] = useState(0);
   const webdavEnvBaseUrl =
     getClientConfig()?.webdavBackendBaseUrl?.trim() || "";
   const webdavEnvPrefix = getClientConfig()?.webdavBackendPrefix?.trim() || "";
@@ -72,6 +75,7 @@ export function StoragePage() {
   const webdavPrefix = syncStore.webdav.baseUrl.trim()
     ? syncStore.webdav.prefix
     : syncStore.webdav.prefix || webdavEnvPrefix;
+  const workspaceAccount = (getCurrentAccount() || "").trim();
 
   const stateOverview = useMemo(() => {
     const sessions = chatStore.sessions;
@@ -118,6 +122,14 @@ export function StoragePage() {
     setQuota(nextQuota);
     setQuotaState(nextQuota ? "ready" : "error");
   };
+
+  useEffect(() => {
+    setWorkspaceSyncDelayMs(getAccountWorkspaceSyncDelayMs());
+    const timer = window.setInterval(() => {
+      setWorkspaceSyncDelayMs(getAccountWorkspaceSyncDelayMs());
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -220,6 +232,13 @@ export function StoragePage() {
               <div className={styles["status-desc"]}>
                 {Locale.Storage.StatusDesc}
               </div>
+              {workspaceSyncDelayMs > 0 ? (
+                <div className={styles["status-hint"]}>
+                  {Locale.Storage.WorkspaceSyncDelay(
+                    Math.ceil(workspaceSyncDelayMs / 1000),
+                  )}
+                </div>
+              ) : null}
               <div className={styles.actions}>
                 <IconButton
                   icon={
@@ -501,6 +520,12 @@ export function StoragePage() {
             {Locale.Storage.DataTitle}
           </div>
           <List>
+            <ListItem
+              title={Locale.Storage.WorkspaceAccount}
+              subTitle={
+                workspaceAccount || Locale.Storage.WorkspaceAccountGuest
+              }
+            />
             <ListItem
               title={Locale.Storage.LastSync}
               subTitle={

--- a/app/hooks/useAutoSync.ts
+++ b/app/hooks/useAutoSync.ts
@@ -8,6 +8,7 @@ import {
   isUcanSignPending,
   isUcanSignPendingError,
 } from "../plugins/ucan-sign-lock";
+import { getAccountWorkspaceSyncDelayMs } from "../utils/account-workspace";
 
 let autoSyncInFlight = false;
 let lastAutoSyncAt = 0;
@@ -49,6 +50,16 @@ export function useAutoSync() {
   const triggerSync = useCallback(
     async (reason: string) => {
       if (!enabled || autoSyncInFlight) return;
+      const workspaceSyncDelayMs = getAccountWorkspaceSyncDelayMs();
+      if (workspaceSyncDelayMs > 0) {
+        if (debounceRef.current) {
+          clearTimeout(debounceRef.current);
+        }
+        debounceRef.current = setTimeout(() => {
+          triggerSync(`${reason}:workspace-delay`);
+        }, workspaceSyncDelayMs);
+        return;
+      }
       const now = Date.now();
       if (now - lastAutoSyncAt < AUTO_SYNC_DEDUPE_WINDOW_MS) return;
       if (isUcanSignPending()) {
@@ -82,12 +93,16 @@ export function useAutoSync() {
   const scheduleSync = useCallback(
     (reason: string) => {
       if (!enabled) return;
+      const workspaceSyncDelayMs = getAccountWorkspaceSyncDelayMs();
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
       }
-      debounceRef.current = setTimeout(() => {
-        triggerSync(reason);
-      }, debounceMs);
+      debounceRef.current = setTimeout(
+        () => {
+          triggerSync(reason);
+        },
+        Math.max(debounceMs, workspaceSyncDelayMs),
+      );
     },
     [debounceMs, enabled, triggerSync],
   );

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -1091,6 +1091,10 @@ const cn = {
     QuotaUsed: "已使用",
     QuotaAvailable: "剩余空间",
     DataTitle: "数据管理",
+    WorkspaceAccount: "当前工作区账号",
+    WorkspaceAccountGuest: "未登录（访客工作区）",
+    WorkspaceSyncDelay: (seconds: number) =>
+      `账号工作区刚切换，自动同步已暂缓约 ${seconds} 秒，避免误覆盖远端数据。`,
     LastSync: "最近同步",
     LocalData: "本地数据",
     Expansion: "存储扩容",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -1114,6 +1114,10 @@ const en: LocaleType = {
     QuotaUsed: "Used",
     QuotaAvailable: "Available",
     DataTitle: "Data Management",
+    WorkspaceAccount: "Current Workspace Account",
+    WorkspaceAccountGuest: "Not signed in (guest workspace)",
+    WorkspaceSyncDelay: (seconds: number) =>
+      `Workspace just switched accounts. Auto sync is paused for about ${seconds}s to avoid overwriting remote data.`,
     LastSync: "Last sync",
     LocalData: "Local data",
     Expansion: "Storage expansion",

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -90,7 +90,7 @@ const isRouterEndpoint = (url: string | undefined): boolean => {
   }
 };
 
-const createDefaultAccessState = () => {
+export const createDefaultAccessState = () => {
   const isExportApp = isApp();
   const defaultOpenAIUrl = getDefaultOpenAIUrl();
 
@@ -188,7 +188,7 @@ const createDefaultAccessState = () => {
   };
 };
 
-const DEFAULT_ACCESS_STATE = createDefaultAccessState();
+export const DEFAULT_ACCESS_STATE = createDefaultAccessState();
 
 const syncRouterBackendUrlSnapshot = (state: typeof DEFAULT_ACCESS_STATE) => {
   const routerBackendUrl = getRouterBackendUrl();

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -389,13 +389,15 @@ async function getToolSystemPrompt(): Promise<string> {
   return TOOL_SYSTEM_TEMPLATE.replace("{{ TOOLS }}", toolsStr);
 }
 
-const DEFAULT_CHAT_STATE = {
+export const createDefaultChatState = () => ({
   sessions: [createEmptySession()],
   currentSessionIndex: 0,
   lastInput: "",
   deletedSessions: {} as Record<string, number>,
   deletedMessages: {} as Record<string, number>,
-};
+});
+
+export const DEFAULT_CHAT_STATE = createDefaultChatState();
 
 export const useChatStore = createPersistStore(
   DEFAULT_CHAT_STATE,

--- a/app/store/prompt.ts
+++ b/app/store/prompt.ts
@@ -12,6 +12,11 @@ export interface Prompt {
   createdAt: number;
 }
 
+export const DEFAULT_PROMPT_STATE = {
+  counter: 0,
+  prompts: {} as Record<string, Prompt>,
+};
+
 export const SearchService = {
   ready: false,
   builtinEngine: new Fuse<Prompt>([], { keys: ["title"] }),
@@ -51,10 +56,7 @@ export const SearchService = {
 };
 
 export const usePromptStore = createPersistStore(
-  {
-    counter: 0,
-    prompts: {} as Record<string, Prompt>,
-  },
+  DEFAULT_PROMPT_STATE,
 
   (set, get) => ({
     add(prompt: Prompt) {

--- a/app/utils/account-workspace.ts
+++ b/app/utils/account-workspace.ts
@@ -1,0 +1,158 @@
+import { safeLocalStorage } from "@/app/utils";
+import { indexedDBStorage } from "@/app/utils/indexedDB-storage";
+import { StoreKey } from "../constant";
+import { UCAN_AUTH_EVENT } from "../plugins/wallet";
+import { useAccessStore, useAppConfig, useChatStore } from "../store";
+import { DEFAULT_ACCESS_STATE } from "../store/access";
+import { DEFAULT_CHAT_STATE } from "../store/chat";
+import { DEFAULT_CONFIG } from "../store/config";
+import { DEFAULT_PROMPT_STATE, usePromptStore } from "../store/prompt";
+import { DEFAULT_SKILL_STATE, useSkillStore } from "../store/skill";
+import { deepClone } from "./clone";
+import { AppState, getLocalAppState, setLocalAppState } from "./sync";
+
+const storage = safeLocalStorage();
+const ACCOUNT_WORKSPACE_OWNER_KEY = "accountWorkspaceOwner";
+const ACCOUNT_WORKSPACE_SNAPSHOT_PREFIX = "accountWorkspaceSnapshot:";
+const GUEST_WORKSPACE_OWNER = "__guest__";
+const ACCOUNT_WORKSPACE_SYNC_COOLDOWN_MS = 15_000;
+
+function normalizeWorkspaceOwner(account?: string | null) {
+  const normalized = (account || "").trim().toLowerCase();
+  return normalized || GUEST_WORKSPACE_OWNER;
+}
+
+function getWorkspaceSnapshotKey(owner: string) {
+  return `${ACCOUNT_WORKSPACE_SNAPSHOT_PREFIX}${owner}`;
+}
+
+function getCurrentAccountOwner() {
+  return normalizeWorkspaceOwner(storage.getItem("currentAccount"));
+}
+
+function createDefaultWorkspaceState(): AppState {
+  return {
+    [StoreKey.Chat]: deepClone(DEFAULT_CHAT_STATE),
+    [StoreKey.Access]: deepClone(DEFAULT_ACCESS_STATE),
+    [StoreKey.Config]: deepClone(DEFAULT_CONFIG),
+    [StoreKey.Skill]: deepClone(DEFAULT_SKILL_STATE),
+    [StoreKey.Prompt]: deepClone(DEFAULT_PROMPT_STATE),
+  } as AppState;
+}
+
+async function saveWorkspaceSnapshot(owner: string) {
+  await indexedDBStorage.setItem(
+    getWorkspaceSnapshotKey(owner),
+    JSON.stringify(getLocalAppState()),
+  );
+}
+
+async function loadWorkspaceSnapshot(owner: string) {
+  const raw = await indexedDBStorage.getItem(getWorkspaceSnapshotKey(owner));
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as AppState;
+  } catch {
+    await indexedDBStorage.removeItem(getWorkspaceSnapshotKey(owner));
+    return null;
+  }
+}
+
+function workspaceStoresHydrated() {
+  return [
+    useChatStore.getState()._hasHydrated,
+    useAccessStore.getState()._hasHydrated,
+    useAppConfig.getState()._hasHydrated,
+    useSkillStore.getState()._hasHydrated,
+    usePromptStore.getState()._hasHydrated,
+  ].every(Boolean);
+}
+
+let hasBoundAccountWorkspaceIsolation = false;
+let workspaceSwitchChain = Promise.resolve();
+let syncSuppressedUntil = 0;
+
+export function getAccountWorkspaceSyncDelayMs() {
+  return Math.max(0, syncSuppressedUntil - Date.now());
+}
+
+async function switchWorkspaceTo(owner: string) {
+  workspaceSwitchChain = workspaceSwitchChain.then(async () => {
+    const normalizedOwner = normalizeWorkspaceOwner(owner);
+    const storedOwner = storage.getItem(ACCOUNT_WORKSPACE_OWNER_KEY);
+
+    if (!storedOwner) {
+      storage.setItem(ACCOUNT_WORKSPACE_OWNER_KEY, normalizedOwner);
+      await saveWorkspaceSnapshot(normalizedOwner);
+      return;
+    }
+
+    const currentOwner = normalizeWorkspaceOwner(storedOwner);
+    if (currentOwner === normalizedOwner) return;
+
+    await saveWorkspaceSnapshot(currentOwner);
+    const nextState =
+      (await loadWorkspaceSnapshot(normalizedOwner)) ||
+      createDefaultWorkspaceState();
+
+    setLocalAppState(nextState);
+    storage.setItem(ACCOUNT_WORKSPACE_OWNER_KEY, normalizedOwner);
+    syncSuppressedUntil = Date.now() + ACCOUNT_WORKSPACE_SYNC_COOLDOWN_MS;
+  });
+
+  return workspaceSwitchChain;
+}
+
+function bindAccountWorkspaceIsolation() {
+  if (typeof window === "undefined" || hasBoundAccountWorkspaceIsolation)
+    return;
+  hasBoundAccountWorkspaceIsolation = true;
+
+  const reconcile = () => {
+    if (!workspaceStoresHydrated()) return;
+    void switchWorkspaceTo(getCurrentAccountOwner());
+  };
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key && event.key !== "currentAccount") return;
+    reconcile();
+  };
+
+  if (workspaceStoresHydrated()) {
+    reconcile();
+  } else {
+    const unsubscribers = [
+      useChatStore.subscribe(() => {
+        if (!workspaceStoresHydrated()) return;
+        unsubscribers.forEach((unsubscribe) => unsubscribe());
+        reconcile();
+      }),
+      useAccessStore.subscribe(() => {
+        if (!workspaceStoresHydrated()) return;
+        unsubscribers.forEach((unsubscribe) => unsubscribe());
+        reconcile();
+      }),
+      useAppConfig.subscribe(() => {
+        if (!workspaceStoresHydrated()) return;
+        unsubscribers.forEach((unsubscribe) => unsubscribe());
+        reconcile();
+      }),
+      useSkillStore.subscribe(() => {
+        if (!workspaceStoresHydrated()) return;
+        unsubscribers.forEach((unsubscribe) => unsubscribe());
+        reconcile();
+      }),
+      usePromptStore.subscribe(() => {
+        if (!workspaceStoresHydrated()) return;
+        unsubscribers.forEach((unsubscribe) => unsubscribe());
+        reconcile();
+      }),
+    ];
+  }
+
+  window.addEventListener(UCAN_AUTH_EVENT, reconcile);
+  window.addEventListener("storage", onStorage);
+}
+
+bindAccountWorkspaceIsolation();


### PR DESCRIPTION
## Summary
- isolate browser-local chat workspace by account and keep a separate guest workspace
- pause auto sync briefly after account workspace switches to avoid overwriting remote state
- surface the current workspace account and sync delay state in storage settings

## Verification
- npm run build
- npx eslint app/utils/account-workspace.ts app/hooks/useAutoSync.ts app/components/home.tsx app/components/storage-page.tsx app/locales/cn.ts app/locales/en.ts app/store/access.ts app/store/chat.ts app/store/prompt.ts