### PR TITLE
change for windows and ubuntu app

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -112,7 +112,7 @@ jobs:
   build-windows-verification:
     runs-on: windows-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout branch
@@ -144,22 +144,48 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run app:build:release
 
+      - name: Prepare Windows release assets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path release-assets | Out-Null
+
+          $rawVersion = "${{ github.event_name == 'release' && github.event.release.tag_name || inputs.build_version }}"
+          if ([string]::IsNullOrWhiteSpace($rawVersion)) {
+            $rawVersion = node -p "require('./src-tauri/tauri.conf.json').version"
+          }
+          $normalizedVersion = $rawVersion -replace '^refs/tags/', ''
+          $normalizedVersion = $normalizedVersion -replace '^[vV]', ''
+          $version = "v$normalizedVersion"
+
+          $msi = Get-ChildItem -Path 'src-tauri/target/release/bundle' -Recurse -Filter '*.msi' -File -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($null -eq $msi) {
+            throw 'No Windows MSI installer found under src-tauri/target/release/bundle'
+          }
+
+          $dest = "chat-$version-Windows.msi"
+          Copy-Item $msi.FullName (Join-Path 'release-assets' $dest) -Force
+          Write-Host "Windows MSI prepared: $dest"
+
       - name: Upload Windows verification artifacts
         uses: actions/upload-artifact@v4
         with:
           name: windows-desktop-verification
-          path: |
-            src-tauri/target/release/chat.exe
-            src-tauri/target/release/bundle/**/*.msi
-            src-tauri/target/release/bundle/**/*.exe
-            src-tauri/target/release/bundle/**/*.sig
-            src-tauri/target/release/bundle/**/latest.json
+          path: release-assets/*.msi
           if-no-files-found: error
 
-  build-ubuntu-verification:
-    runs-on: ubuntu-latest
+      - name: Upload Windows release assets
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: release-assets/*.msi
+
+  build-ubuntu24-04-verification:
+    name: build-ubuntu24.04-verification
+    runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout branch
@@ -179,14 +205,14 @@ jobs:
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:
-          key: ubuntu-verification
+          key: ubuntu24.04-verification
 
       - name: Install Ubuntu desktop dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
+            libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
 
@@ -200,14 +226,41 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run app:build:release
 
+      - name: Prepare Ubuntu 24.04 release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+
+          RAW_VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.build_version }}"
+          if [ -z "$RAW_VERSION" ]; then
+            RAW_VERSION="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+          fi
+          NORMALIZED_VERSION="${RAW_VERSION#refs/tags/}"
+          NORMALIZED_VERSION="${NORMALIZED_VERSION#v}"
+          NORMALIZED_VERSION="${NORMALIZED_VERSION#V}"
+          VERSION="v${NORMALIZED_VERSION}"
+
+          DEB="$(find src-tauri/target/release/bundle -name '*.deb' -type f | head -1 || true)"
+          if [ -z "$DEB" ]; then
+            echo "No Ubuntu .deb installer found under src-tauri/target/release/bundle" >&2
+            exit 1
+          fi
+
+          DEST="chat-${VERSION}-Ubuntu24.04-x86_64.deb"
+          cp "$DEB" "release-assets/$DEST"
+          echo "Ubuntu 24.04 deb prepared: $DEST"
+
       - name: Upload Ubuntu verification artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ubuntu-desktop-verification
-          path: |
-            src-tauri/target/release/chat
-            src-tauri/target/release/bundle/**/*.deb
-            src-tauri/target/release/bundle/**/*.AppImage
-            src-tauri/target/release/bundle/**/*.sig
-            src-tauri/target/release/bundle/**/latest.json
+          name: ubuntu24.04-desktop-verification
+          path: release-assets/*.deb
           if-no-files-found: error
+
+      - name: Upload Ubuntu 24.04 release assets
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: release-assets/*.deb


### PR DESCRIPTION
对.github/workflows/app.yml文件进行修改，参考https://github.com/farion1231/cc-switch/blob/main/.github/workflows下面的文件
1. build-windows-verification生成的文件名称为chat-v版本号-Windows.msi
2. build-ubuntu-verification更新为build-ubuntu24.04-verification 更新runs-on为ubuntu-24.04，执行后生成的文件名称为
chat-v版本号-Ubuntu24.04-x86_64.deb
3. 生成的这些文件放到Assets下面，可以参考https://github.com/farion1231/cc-switch/releases/tag/v3.19.2这个页面